### PR TITLE
fail fast when user tries to serve onnx model directly

### DIFF
--- a/mms/model_loader.py
+++ b/mms/model_loader.py
@@ -92,14 +92,15 @@ def _extract_zip(zip_file, destination):
                 shutil.copyfileobj(source, target)
 
 def _extract_model(service_name, path):
-    curr_dir = os.getcwd()
-    
+    if path.endswith('.onnx') or path.endswith('.pb2'):
+        raise ValueError('Convert ONNX model using mxnet-model-export before serving.')
+
     model_file = download(url=path, overwrite=True) \
     if path.lower().startswith(URL_PREFIX) else path
 
     model_file = os.path.abspath(model_file)
-    [model_name, model_extenstion] = os.path.splitext(os.path.basename(model_file))
-    model_file_prefix = model_name if model_extenstion == '.model' else model_file
+    [model_name, model_extension] = os.path.splitext(os.path.basename(model_file))
+    model_file_prefix = model_name if model_extension == '.model' else model_file
     model_dir = os.path.join(os.path.dirname(model_file), model_file_prefix)
 
     if not os.path.isdir(model_dir):

--- a/mms/tests/integration_tests/extend_export_predict_service_test.py
+++ b/mms/tests/integration_tests/extend_export_predict_service_test.py
@@ -78,7 +78,7 @@ def test_ssd_extend_export_predict_service(tmpdir):
     start_test_server_thread = Thread(target = setup_ssd_server, args=(str(tmpdir),))
     start_test_server_thread.daemon = True
     start_test_server_thread.start()
-    time.sleep(15)
+    time.sleep(60)
     output = subprocess.check_output('curl -X POST http://127.0.0.1:8080/SSD/predict -F "data=@{}/street.jpg"'.format(str(tmpdir)), shell=True)
     if sys.version_info[0] >= 3:
         output = output.decode("utf-8")

--- a/mms/tests/integration_tests/onnx_export_integ_test.py
+++ b/mms/tests/integration_tests/onnx_export_integ_test.py
@@ -69,7 +69,7 @@ def test_onnx_integ(tmpdir):
     start_test_server_thread = Thread(target = setup_onnx_integ, args=(str(tmpdir),))
     start_test_server_thread.daemon = True
     start_test_server_thread.start()
-    time.sleep(15)
+    time.sleep(60)
     output = subprocess.check_output('curl -X POST http://127.0.0.1:8080/squeezenet/predict -F "input_0=@{}/Cute-kittens-12929201-1600-1200.jpg"'.format(str(tmpdir)), shell=True)
     if sys.version_info[0] >= 3:
         output = output.decode("utf-8")

--- a/mms/tests/unit_tests/test_model_loader.py
+++ b/mms/tests/unit_tests/test_model_loader.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+import sys
+
+curr_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(curr_path + '/../..')
+
+from mms.model_loader import ModelLoader
+
+def test_onnx_fails_fast():
+    models = { 'onnx': 's3://bucket/prefix/whatever.onnx'}
+
+    with pytest.raises(ValueError) as e:
+        ModelLoader.load(models)
+
+    assert 'Convert ONNX model' in str(e.value)


### PR DESCRIPTION
fixes issue #260 

launching model server with an onnx model:

```mxnet-model-server   --port 9999   --models squeezenet=https://s3.amazonaws.com/model-server/models/onnx-vgg19/vgg19.onnx```

now fails with error immediately, instead of downloading and showing confusing message later:

```
mxnet-model-server   --port 9999   --models squeezenet=https://s3.amazonaws.com/model-server/models/onnx-vgg19/vgg19.onnx
[ ...site-packages/mms/mxnet_model_server.py:__init__:94] Initialized model serving.
[ ...site-packages/mms/mxnet_model_server.py:_arg_process:185] Failed to process arguments: Use mxnet-model-export to convert ONNX model before serving.
```