### PR TITLE
Fix epoch number validation

### DIFF
--- a/mms/export_model.py
+++ b/mms/export_model.py
@@ -240,7 +240,7 @@ def find_unique(files, suffix):
 
 
 def validate_epoch_number(params_file):
-    if re.match(r'^.+-\d+\.params$', params_file) is None:
+    if re.match(r'^[\w\-\.]+-\d+\.params$', params_file) is None:
         raise ValueError(NO_EPOCH_NUMBER_MESSAGE.format(params_file))
 
 

--- a/mms/export_model.py
+++ b/mms/export_model.py
@@ -240,7 +240,7 @@ def find_unique(files, suffix):
 
 
 def validate_epoch_number(params_file):
-    if re.match(r'^\w+-\d+\.params$', params_file) is None:
+    if re.match(r'^.+-\d+\.params$', params_file) is None:
         raise ValueError(NO_EPOCH_NUMBER_MESSAGE.format(params_file))
 
 


### PR DESCRIPTION
In the current implementation, only alphanumeric characters and
underscore can be specified in the model name.

Currently, epoch number validation fails in case of model name
`imagenet1k-nin-0000.params`. In addition, validation also fails in
case `squeezenet_v1.1-0000.params` is shown in the export example.

So I changed the regular expression in epoch number validation from
`r'^\w+-\d+\.params$'` to `r'^.+-\d+\.params$'` so that symbols other
than underscore are allowed.