### PR TITLE
Fix validate_prefix_match

### DIFF
--- a/mms/export_model.py
+++ b/mms/export_model.py
@@ -246,7 +246,7 @@ def validate_epoch_number(params_file):
 
 def validate_prefix_match(symbol_file, params_file):
     symbol_prefix = symbol_file.replace('-symbol.json', '')
-    params_prefix = params_file.split('-')[0]  # safe because of preceding regex
+    params_prefix = re.sub(r'-\d+\.params$', '', params_file)
     if symbol_prefix != params_prefix:
         raise ValueError(MODEL_PREFIX_MISMATCH_MESSAGE.format(symbol_file, params_file))
 


### PR DESCRIPTION
Fix prefix validation due to modification of epoch number validation of
params file (#298).

The original verification assumes that the prefix of params file name does not contain a hyphen.

I corrupted the code due to my pull request(#298), sorry for the inconvenience.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
