### PR TITLE
Modified how we call mxnet-model-server in container

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -23,6 +23,7 @@ RUN apt-get update && \
     && python get-pip.py \
     && pip install gevent gunicorn \
     && pip install --pre mxnet-model-server \
+    && pip uninstall --yes mxnet \
     && pip install mxnet-mkl \
     && mkdir /mxnet_model_server
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -27,7 +27,7 @@ RUN apt-get update && \
     && pip install mxnet-mkl \
     && mkdir /mxnet_model_server
 
-COPY wsgi.py setup_mms.py mxnet-model-server.sh /mxnet_model_server/
+COPY wsgi.py setup_mms.py mxnet-model-server /mxnet_model_server/
 
 ENV PATH="/mxnet_model_server:${PATH}" MXNET_MODEL_SERVER_GPU_IMAGE=0
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -21,7 +21,8 @@ RUN apt-get update && \
     && cd /tmp \
     && curl -O https://bootstrap.pypa.io/get-pip.py \
     && python get-pip.py \
-    && pip install gevent gunicorn mxnet-model-server==0.3.0b1 \
+    && pip install gevent gunicorn \
+    && pip install --pre mxnet-model-server \
     && pip uninstall --yes mxnet \
     && pip install mxnet-mkl \
     && mkdir /mxnet_model_server

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -23,7 +23,6 @@ RUN apt-get update && \
     && python get-pip.py \
     && pip install gevent gunicorn \
     && pip install --pre mxnet-model-server \
-    && pip uninstall --yes mxnet \
     && pip install mxnet-mkl \
     && mkdir /mxnet_model_server
 

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -26,7 +26,7 @@ RUN apt-get update && \
     && pip install --no-cache-dir mxnet-cu90 \
     && mkdir /mxnet_model_server
 
-COPY wsgi.py setup_mms.py mxnet-model-server.sh /mxnet_model_server/
+COPY wsgi.py setup_mms.py mxnet-model-server /mxnet_model_server/
 
 ENV PATH="/mxnet_model_server:${PATH}" MXNET_MODEL_SERVER_GPU_IMAGE=1 gpu_id=0
 

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -21,7 +21,8 @@ RUN apt-get update && \
     && cd /tmp \
     && curl -O https://bootstrap.pypa.io/get-pip.py \
     && python get-pip.py \
-    && pip install gevent gunicorn mxnet-model-server==0.3.0b1 \
+    && pip install gevent gunicorn \
+    && pip install --pre mxnet-model-server \
     && pip install --no-cache-dir mxnet-cu90 \
     && mkdir /mxnet_model_server
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,11 +34,12 @@ Docker images are currently available on Docker Hub [CPU](https://hub.docker.com
    ``` 
    Verify the models and configuration file is in this newly created directory. Also verify that the `mms_app_[cpu|gpu].conf` is updated.
 
-3. Run the downloaded Docker image
+3. Run the downloaded CPU container image
    ```bash
    docker run --name mms -p 80:8080 -itd -v /home/users/models/:/models awsdeeplearningteam/mms_cpu
    0c1862a2c30edd0f33391f7277b2c8bcba4a5f4cf22669f3b308b4078a5d3ce8
    ```
+   Note, to run GPU image refer [this section](#running-the-mms-gpu-docker)
    
    Verify the image is running
    ```bash
@@ -48,13 +49,13 @@ Docker images are currently available on Docker Hub [CPU](https://hub.docker.com
    ```
    Refer [Docker CLI](https://docs.docker.com/engine/reference/commandline/run/) to understand each parameter. 
 
-4. Run MXNet Model Server in the running instance of Docker
+4. Run MXNet Model Server in the running instance of the container
    ```bash
    docker exec mms bash -c "mxnet-model-server start --mms-config /models/mms_app_cpu.conf"
    ``` 
 
-## Building `MMS docker` image from scratch
-The following are the steps to build a docker image
+## Building `MMS container` image from scratch
+The following are the steps to build a container image from scratch.
 
 ### Prerequisites
 In order to build the Docker image yourself you need the following:
@@ -86,7 +87,7 @@ If you haven't already, clone the MMS repo and go into the `docker` folder.
 git clone https://github.com/awslabs/mxnet-model-server.git && cd mxnet-model-server/docker
 ```
 
-### Building the Docker Image
+### Building the Container Image
 
 #### Configuration Setup
 
@@ -126,7 +127,7 @@ The next command will build the Docker image. The `-t` flag and following value 
 docker build -f Dockerfile.cpu -t mms_image .
 ```
 
-Once this completes, run `docker images` from your terminal. You should see the Docker image listed with the tag, `mms_image:latest`. Skip down to the section **Running the MMS Docker** to continue, or peruse the EC2 instructions if you're curious how to configure it for the cloud.
+Once this completes, run `docker images` from your terminal. You should see the Docker image listed with the tag, `mms_image:latest`. 
 
 ### Build Step for GPU
 
@@ -244,7 +245,6 @@ The predict endpoint will return a prediction response in JSON. It will look som
   ]
 }
 ```
-
 
 ## Advanced Settings
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-# MXNet Model Server with Docker
+# MXNet Model Server in a container
 
 Docker images are currently available on Docker Hub [CPU](https://hub.docker.com/r/awsdeeplearningteam/mms_cpu/), [GPU](https://hub.docker.com/r/awsdeeplearningteam/mms_gpu/). Running MXNet Model Server in the docker instance can be done with four easy steps
 
@@ -46,13 +46,14 @@ Docker images are currently available on Docker Hub [CPU](https://hub.docker.com
    CONTAINER ID        IMAGE               COMMAND             CREATED                  STATUS              PORTS                NAMES
    b4bab087f2a8        mms_cpu             "/bin/bash"         Less than a second ago   Up 2 seconds        0.0.0.0:80->80/tcp   mms
    ```
+   Refer [Docker CLI](https://docs.docker.com/engine/reference/commandline/run/) to understand each parameter. 
 
-3. Run MXNet Model Server in the running instance of Docker
+4. Run MXNet Model Server in the running instance of Docker
    ```bash
-   docker exec mms bash -c "mxnet-model-server.sh start --mms-config /models/mms_app_cpu.conf"
+   docker exec mms bash -c "mxnet-model-server start --mms-config /models/mms_app_cpu.conf"
    ``` 
 
-## Building a fresh docker image from the repository   
+## Building `MMS docker` image from scratch
 The following are the steps to build a docker image
 
 ### Prerequisites
@@ -158,14 +159,6 @@ You may also want to modify the `-p 80:8080` to utilize other ports instead. Ref
 # Run the docker image in a detached mode
 $ docker run -itd -p 80:8080 --name mms -v /home/user/models:/models mms_image:latest
 ```
-
-To run the MMS with $HOSTNAME as its endpoint, or for `nginx's server_name` to be configured to `$HOSTNAME` run the following command.
-```bash
-# Start docker with nginx's server_name configured to $HOSTNAME
-$ docker run -itd -p 80:8080 --name mms -v /home/user/models:/models -e MXNET_MODEL_SERVER_HOST=$HOSTNAME mms_image:latest
-```
-The above command lets you run inference with `$HOSTNAME` as 'server_name'.
-Refer [Docker CLI](https://docs.docker.com/engine/reference/commandline/run/) to understand each parameter.   
    
 Verify that this image is running by running 
 ```bash
@@ -186,7 +179,7 @@ $ docker ps -a
 
 ```bash
 # To start the MMS run the following
-$ docker exec mms bash -c "mxnet-model-server.sh start --mms-config /models/mms_app_cpu.conf"
+$ docker exec mms bash -c "mxnet-model-server start --mms-config /models/mms_app_cpu.conf"
 ```
 
 This will setup the MMS endpoint, gunicorn wsgi entry point, and nginx proxy_pass. 
@@ -202,7 +195,7 @@ This command starts the docker instance in a detached mode and mounts `/home/use
 Considering that you modified and copied `mms_app_gpu.conf` file into the models directory, before you ran the above `nvidia-docker` command, you would have this configuration file ready to use in the docker instance.
 
 ```bash
-$ nvidia-docker exec mms bash -c "mxnet-model-server.sh start --mms-config /models/mms_app_gpu.conf"
+$ nvidia-docker exec mms bash -c "mxnet-model-server start --mms-config /models/mms_app_gpu.conf"
 ```
 You can change the gunicorn argument `--workers` to change utilization of GPU resources. Each worker will utilize one GPU device. Currently up to 4 workers are recommended to get optimal performance for CPU and this should be set to the `number of GPUs` in case of running MXNet Model Server on GPU instances.
 
@@ -214,7 +207,8 @@ Now you can send a request to your server's [api-description endpoint](http://lo
 * [http://localhost:8080/api-description](http://localhost/api-description)
 * [http://localhost/ping](http://localhost/ping)
 
-If the `mms_app_[gpu|cpu].conf` is used as is, the following commands can be run to verify that the MXNet Model Server is running.
+If `mms_app_gpu.conf` or `mms_app_cpu.conf` files are used as is, the following commands can be run to verify that the MXNet Model Server is running.
+
 ```bash
 $ curl -O https://s3.amazonaws.com/model-server/inputs/kitten.jpg
 $ curl -X POST http://127.0.0.1:8080/squeezenet/predict -F "data=@kitten.jpg"
@@ -332,7 +326,6 @@ server {
     listen       80;
     listen       443 ssl;
 
-    server_name  your_public_host_name;
     ssl_certificate /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
@@ -357,31 +350,31 @@ curl -X GET http://your_public_host_name/ping
 ### Stopping the current MMS instance
 To stop the MMS running inside the docker instance, run the following
 ```bash
-$ docker exec mms bash -c "mxnet-model-server.sh stop"
+$ docker exec mms bash -c "mxnet-model-server stop"
 ```
 
 ### Usage help for MMS
 ```bash
-docker exec mms bash -c "mxnet-model-server.sh help"
+docker exec mms bash -c "mxnet-model-server help"
 ```
 ```text
 Usage:
 
-/mxnet_model_server/mxnet-model-server.sh [start | stop | restart | help] [--mms-config <MMS config file>]
+mxnet-model-server [start | stop | restart | help] [--mms-config <MMS config file>]
 
 start        : Start a new instance of MXNet model server
 stop         : Stop the current running instance of MXNet model server
 restart      : Restarts all the MXNet Model Server worker instances
-help         : Usage help for /mxnet_model_server/mxnet-model-server.sh
+help         : Usage help for /mxnet_model_server/mms
 --mms-config : Location pointing to the MXNet model server configuration file
 To start the MXNet model server, run
-/mxnet_model_server/mxnet-model-server.sh start --mms-config <path-to-config-file>
+/mxnet_model_server/mxnet-model-server start --mms-config <path-to-config-file>
 
 To stop the running instance of MXNet model server, run
-/mxnet_model_server/mxnet-model-server.sh stop
+/mxnet_model_server/mxnet-model-server stop
 
 To restart the running instance of MXNet model server, run
-/mxnet_model_server/mxnet-model-server.sh restart --mms-config <path-to-config-file>
+/mxnet_model_server/mxnet-model-server restart --mms-config <path-to-config-file>
 ```
 
 ### Debugging or logging into the running docker instance

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,14 +29,14 @@ Docker images are currently available on Docker Hub [CPU](https://hub.docker.com
    Update the `--models` option in the configuration in the mms_app_[cpu|gpu].conf file. Also update the `--log-file` to point to a the file-path `/models/mms_app.log`.
 
    ```bash
-   mkdir /home/user/models
-   cp ~/mxnet-model-server/docker/mms_app_cpu.conf /home/user/models/.
+   mkdir /tmp/models
+   cp ~/mxnet-model-server/docker/mms_app_cpu.conf /tmp/models/.
    ``` 
    Verify the models and configuration file is in this newly created directory. Also verify that the `mms_app_[cpu|gpu].conf` is updated.
 
 3. Run the downloaded CPU container image
    ```bash
-   docker run --name mms -p 80:8080 -itd -v /home/users/models/:/models awsdeeplearningteam/mms_cpu
+   docker run --name mms -p 80:8080 -itd -v /tmp/models/:/models awsdeeplearningteam/mms_cpu
    0c1862a2c30edd0f33391f7277b2c8bcba4a5f4cf22669f3b308b4078a5d3ce8
    ```
    Note, to run GPU image refer to [this section](#running-the-mms-gpu-docker)
@@ -151,8 +151,8 @@ docker build -f Dockerfile.gpu -t mms_image_gpu .
 Create a `models` directory on the host machine and add the models to be used along with the mms_app_[cpu|gpu].conf file into the directory. Modify the `mms_app[cpu/gpu].conf` file to reflect the model files to be used along with updated options for other `gunicorn`, `nginx` and `MMS` configurations.
  ```bash
  # Modify the mms_app_cpu.conf or mms_app_gpu.conf and add it to this folder
- $ mkdir models
- $ cp ~/mxnet-model-server/docker/mms_app_cpu.conf models/
+ $ mkdir /tmp/models
+ $ cp ~/mxnet-model-server/docker/mms_app_cpu.conf /tmp/models/
  ```
 ### Running MXNet Model Server as a Docker instance
 
@@ -164,7 +164,7 @@ You may also want to modify the `-p 80:8080` to utilize other ports instead. Ref
 
 ```bash
 # Run the docker image in a detached mode
-$ docker run -itd -p 80:8080 --name mms -v /home/user/models:/models mms_image:latest
+$ docker run -itd -p 80:8080 --name mms -v /tmp/models:/models mms_image:latest
 ```
    
 Verify that this image is running by running 
@@ -195,11 +195,12 @@ At this point you should be able to run inference on `localhost` port `80`
 #### Running the MMS GPU Docker
 
 ```bash
-$ nvidia-docker run -itd -p 80:8080 --name mms -v /home/user/models/:/models mms_image_gpu:latest
+$ nvidia-docker run -itd -p 80:8080 --name mms -v /tmp/models/:/models mms_image_gpu:latest
 ```
 
-This command starts the docker instance in a detached mode and mounts `/home/user/models` of the host system into `/models` directory inside the Docker instance. 
-Considering that you modified and copied `mms_app_gpu.conf` file into the models directory, before you ran the above `nvidia-docker` command, you would have this configuration file ready to use in the docker instance.
+This command starts the docker instance in a detached mode and mounts `/tmp/models` of the host system into `/models` directory inside the Docker instance. 
+Considering that you modified and copied `mms_app_gpu.conf` file into the `/tmp/models` directory, before you ran the above `nvidia-docker` command, 
+you would have this configuration file ready to use in the docker instance.
 
 ```bash
 $ nvidia-docker exec mms bash -c "mxnet-model-server start --mms-config /models/mms_app_gpu.conf"
@@ -324,7 +325,7 @@ First of all, we need to get a SSL certificate. It includes a server certificate
 Second step is to create a docker container which exposes TCP port 443 for SSL:
 
 ```bash
-docker run -itd --name mms -v /home/user/models/:/models -p 8080:443 -p 8081:80 mms_image:latest
+docker run -itd --name mms -v /tmp/models/:/models -p 8080:443 -p 8081:80 mms_image:latest
 ```
 
 Note that we expose both https and normal http ports.

--- a/docker/mms_app_cpu.conf
+++ b/docker/mms_app_cpu.conf
@@ -36,8 +36,7 @@ gevent
 
 [Nginx Configurations]
 server {
-    listen       80;
-    server_name  localhost;
+    listen       8080;
 
     location / {
         proxy_pass http://unix:/tmp/mms_app.sock;

--- a/docker/mms_app_gpu.conf
+++ b/docker/mms_app_gpu.conf
@@ -36,8 +36,7 @@ gevent
 
 [Nginx Configurations]
 server {
-    listen       80;
-    server_name  localhost;
+    listen       8080;
 
     location / {
         proxy_pass http://unix:/tmp/mms_app.sock;

--- a/docker/mms_app_gpu.conf
+++ b/docker/mms_app_gpu.conf
@@ -35,7 +35,6 @@ gevent
 0
 
 [Nginx Configurations]
-
 server {
     listen       80;
     server_name  localhost;

--- a/docker/mxnet-model-server
+++ b/docker/mxnet-model-server
@@ -73,7 +73,7 @@ start_mms()
     	    then
     	    # MXNET_MODEL_SERVER_HOST gets updated when you run Docker (run/exec) command with the environment
     	    #    variables MXNET_MODEL_SERVER_HOST=$HOSTNAME
-  	        if [[ ( "$line" =~ "server_name" ) && ( ! -z ${MXNET_MODEL_SERVER// } ) ]]
+  	        if [[ ( "$line" =~ "server_name" ) && ( ! -z ${MXNET_MODEL_SERVER_HOST// } ) ]]
    	        then
    	            host_name=$MXNET_MODEL_SERVER_HOST
    	            line="server_name $host_name;"
@@ -118,11 +118,11 @@ usage_help() {
     echo ""
     echo "$0 [start | stop | restart | help] [--mms-config <MMS config file>]"
     echo ""
-    echo "start        : Start a new instance of MXNet model server."
+    echo "start        : Start a new instance of MXNet model server"
     echo "stop         : Stop the current running instance of MXNet model server"
-    echo "restart      : Restarts all the MXNet Model Server worker instances."
+    echo "restart      : Restarts all the MXNet Model Server worker instances"
     echo "help         : Usage help for $0"
-    echo "--mms-config : Location pointing to the MXNet model server configuration file."
+    echo "--mms-config : Location pointing to the MXNet model server configuration file"
     echo "To start the MXNet model server, run"
     echo "$0 start --mms-config <path-to-config-file>"
     echo ""

--- a/examples/lstm_ptb/README.md
+++ b/examples/lstm_ptb/README.md
@@ -20,7 +20,7 @@ wget https://s3.amazonaws.com/model-server/models/lstm_ptb/lstm_ptb_service.py
 ## Step 2 - Check signature file
 
 Let's take a look at signature file:
-```
+```json
 {
   "inputs": [
     {
@@ -65,7 +65,7 @@ mxnet-model-server --models lstm_ptb=lstm_ptb.model
 ```
 You will see the following outputs which means the service is successfully established:
 
-```
+```bash
 I1102 11:25:58 4873 /Users/user/anaconda/lib/python2.7/site-packages/mxnet_model_server-0.1.1-py2.7.egg/mms/mxnet_model_server.py:__init__:75] Initialized model serving.
 I1102 11:25:59 4873 /Users/user/anaconda/lib/python2.7/site-packages/mxnet_model_server-0.1.1-py2.7.egg/mms/serving_frontend.py:add_endpoint:177] Adding endpoint: lstm_ptb_predict to Flask
 I1102 11:25:59 4873 /Users/user/anaconda/lib/python2.7/site-packages/mxnet_model_server-0.1.1-py2.7.egg/mms/serving_frontend.py:add_endpoint:177] Adding endpoint: ping to Flask
@@ -89,7 +89,7 @@ curl -X POST http://127.0.0.1:8080/lstm_ptb/predict -F "data=[{'input_sentence':
 
 Prediction result will be:
 
-```
+```bash
 {
   "prediction": "the <unk> 's the the as the 's the the 're to a <unk> <unk> <unk> analyst company trading at "
 }
@@ -97,13 +97,13 @@ Prediction result will be:
 
 Let's try another sentence:
 
-```
+```bash
 curl -X POST http://127.0.0.1:8080/lstm_ptb/predict -F "data=[{'input_sentence': 'while friday \'s debacle involved mainly professional traders rather than investors it left the market vulnerable to continued selling this morning traders said '}]"
 ```
 
 Prediction result will be:
 
-```
+```bash
 {
   "prediction": "the 's stock were <unk> in <unk> say than <unk> were will to <unk> to to the <unk> the week \n \n \n \n \n \n \n \n \n \n "
 }

--- a/examples/lstm_ptb/lstm_ptb_service.py
+++ b/examples/lstm_ptb/lstm_ptb_service.py
@@ -5,11 +5,13 @@ import json
 from mms.model_service.mxnet_model_service import MXNetBaseService
 from mms.utils.mxnet import nlp
 
+
 class MXNetLSTMService(MXNetBaseService):
     """LSTM service class. This service consumes a sentence
     from length 0 to 60 and generates a sentence with the same size.
     """
     def __init__(self, model_name, model_dir, manifest, gpu=None):
+        self.model_name = model_name
         self.ctx = mx.gpu(int(gpu)) if gpu is not None else mx.cpu()
         signature_file_path = os.path.join(model_dir, manifest['Model']['Signature'])
         if not os.path.isfile(signature_file_path):
@@ -19,7 +21,7 @@ class MXNetLSTMService(MXNetBaseService):
             signature_file = open(signature_file_path)
             self._signature = json.load(signature_file)
         except:
-            raise Exception('Failed to open model signiture file: %s' % signature_file_path)
+            raise Exception('Failed to open model signature file: %s' % signature_file_path)
             
         self.data_names = []
         self.data_shapes = []

--- a/mms/log.py
+++ b/mms/log.py
@@ -56,6 +56,7 @@ class _Formatter(logging.Formatter):
             self._fmt = fmt
         return super(_Formatter, self).format(record)
 
+
 def getLogger(name=None, filename=None, filemode=None, level='NOTSET'):
     """Gets a customized logger.
 
@@ -65,6 +66,7 @@ def getLogger(name=None, filename=None, filemode=None, level='NOTSET'):
     warnings.warn("getLogger is deprecated, Use get_logger instead.",
                   DeprecationWarning, stacklevel=2)
     return get_logger(name, filename, filemode, LOG_LEVEL_DICT[level])
+
 
 def get_logger(name=None, filename=None, level="NOTSET", rotate_value='H', rotate_interval=1):
     """Gets a customized logger.

--- a/mms/model_loader.py
+++ b/mms/model_loader.py
@@ -14,12 +14,9 @@ import requests
 import zipfile
 import shutil
 import json
-import jsonschema
-import fasteners
 
 from mms.log import get_logger
 from jsonschema import validate
-
 
 logger = get_logger()
 

--- a/mms/model_service/mxnet_model_service.py
+++ b/mms/model_service/mxnet_model_service.py
@@ -17,7 +17,7 @@ import zipfile
 import json
 import shutil
 import os
-
+import time
 from mxnet.io import DataBatch
 from mms.log import get_logger
 from mms.model_service.model_service import SingleNodeService, URL_PREFIX

--- a/mms/utils/timeit_decorator.py
+++ b/mms/utils/timeit_decorator.py
@@ -1,0 +1,31 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import time
+from functools import wraps
+
+
+def timeit(func):
+    """
+    Use this decorator on a method to find it's execution time.
+    :param func:
+    :return:
+    """
+    @wraps(func)
+    def time_and_log(*args, **kwargs):
+        start = time.time()
+        start_cpu = time.clock()
+        result = func(*args, **kwargs)
+        end = time.time()
+        end_cpu = time.clock()
+        print ("func: %r took a total of %2.4f sec to run and %2.4f sec of CPU time\n" % (func.__name__, (end-start), (end_cpu - start_cpu)))
+        return result
+    return time_and_log


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I have modified the way we call mxnet-model-server inside container runs. I have overloaded the existing mxnet-model-server (standalone way of calling). So, when we call "mxnet-model-server" in docker, it calls the containerized (nginx, gunicorn, flask) version of mxnet-model-server scripts. Also added a timeit util to time the methods and added a default config in the container.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
