### PR TITLE
updating pip package to support mxnet-mkl or cu90mkl by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,13 @@ pkgs.append('tools')
 # $ pip install wheel
 # $ python setup.py bdist_wheel --universal
 # $ twine upload dist/*
-requirements = ['mxnet-mkl>=1.1', 'Flask', 'Pillow', 'requests', 'flask-cors',
+requirements = ['Flask', 'Pillow', 'requests', 'flask-cors',
                 'psutil', 'jsonschema', 'onnx-mxnet>=0.4.2', 'boto3', 'importlib2',
                 'fasteners']
 if platform.system() == 'Linux':
-    requirements[0] = 'mxnet-cu90mkl>=1.1'
+    requirements = ['mxnet-cu90mkl>=1.1'] + requirements
+else:
+    requirements = ['mxnet-mkl>=1.1'] + requirements
 setup(
     name='mxnet-model-server',
     version='0.3',

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ pkgs.append('tools')
 # $ pip install wheel
 # $ python setup.py bdist_wheel --universal
 # $ twine upload dist/*
-requirements = ['mxnet-mkl>=1.1', 'Flask', 'Pillow', 'requests', 'flask-cors',
+requirements = ['mxnet-mkl', 'Flask', 'Pillow', 'requests', 'flask-cors',
                 'psutil', 'jsonschema', 'onnx-mxnet>=0.4.2', 'boto3', 'importlib2',
                 'fasteners']
 if platform.system() == 'Linux':
-    requirements[0] = 'mxnet-cu90mkl>=1.1'
+    requirements[0] = 'mxnet-cu90mkl'
 setup(
     name='mxnet-model-server',
     version='0.3',

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from setuptools import setup, find_packages
 import platform
+from setuptools import setup, find_packages
 
 pkgs = find_packages()
 pkgs.append('tools')
@@ -23,8 +23,9 @@ pkgs.append('tools')
 # $ pip install wheel
 # $ python setup.py bdist_wheel --universal
 # $ twine upload dist/*
-requirements = ['mxnet-mkl>=1.1', 'Flask', 'Pillow', 'requests', 'flask-cors', 'psutil', 'jsonschema',
-                  'onnx-mxnet>=0.4.2', 'boto3', 'importlib2', 'fasteners']
+requirements = ['mxnet-mkl>=1.1', 'Flask', 'Pillow', 'requests', 'flask-cors',
+                'psutil', 'jsonschema', 'onnx-mxnet>=0.4.2', 'boto3', 'importlib2',
+                'fasteners']
 if platform.system() == 'Linux':
     requirements[0] = 'mxnet-cu90mkl>=1.1'
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ pkgs.append('tools')
 # $ pip install wheel
 # $ python setup.py bdist_wheel --universal
 # $ twine upload dist/*
-requirements = ['mxnet-mkl', 'Flask', 'Pillow', 'requests', 'flask-cors',
+requirements = ['mxnet-mkl>=1.1', 'Flask', 'Pillow', 'requests', 'flask-cors',
                 'psutil', 'jsonschema', 'onnx-mxnet>=0.4.2', 'boto3', 'importlib2',
                 'fasteners']
 if platform.system() == 'Linux':
-    requirements[0] = 'mxnet-cu90mkl'
+    requirements[0] = 'mxnet-cu90mkl>=1.1'
 setup(
     name='mxnet-model-server',
     version='0.3',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@
 # permissions and limitations under the License.
 
 from setuptools import setup, find_packages
+import platform
 
 pkgs = find_packages()
 pkgs.append('tools')
@@ -22,7 +23,10 @@ pkgs.append('tools')
 # $ pip install wheel
 # $ python setup.py bdist_wheel --universal
 # $ twine upload dist/*
-
+requirements = ['mxnet-mkl>=1.1', 'Flask', 'Pillow', 'requests', 'flask-cors', 'psutil', 'jsonschema',
+                  'onnx-mxnet>=0.4.2', 'boto3', 'importlib2', 'fasteners']
+if platform.system() == 'Linux':
+    requirements[0] = 'mxnet-cu90mkl>=1.1'
 setup(
     name='mxnet-model-server',
     version='0.3',
@@ -30,8 +34,7 @@ setup(
     url='https://github.com/awslabs/mxnet-model-server',
     keywords='MXNet Model Server Serving Deep Learning Inference AI',
     packages=pkgs,
-    install_requires=['mxnet>=1.1', 'Flask', 'Pillow', 'requests', 'flask-cors', 'psutil', 'jsonschema',
-                      'onnx-mxnet>=0.4.2', 'boto3', 'importlib2', 'fasteners'],
+    install_requires=requirements,
     entry_points={
         'console_scripts': ['mxnet-model-server=mms.mxnet_model_server:start_serving',
                             'mxnet-model-export=mms.export_model:export']

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ pkgs.append('tools')
 requirements = ['Flask', 'Pillow', 'requests', 'flask-cors',
                 'psutil', 'jsonschema', 'onnx-mxnet>=0.4.2', 'boto3', 'importlib2',
                 'fasteners']
-if platform.system() == 'Linux':
+if platform.system().lower() == 'linux':
     requirements = ['mxnet-cu90mkl>=1.1'] + requirements
 else:
     requirements = ['mxnet-mkl>=1.1'] + requirements


### PR DESCRIPTION
*Issue #, if available:*
#362 
*Description of changes:*

Now setup.py installs mxnet-mkl for non-linux distributions and mxnet-cu90mkl for linux distributions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
