### PR TITLE
Locked onnx to 1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join("mms", "version.py")) as f:
     exec(f.read())
 
 requirements = ['Flask', 'Pillow', 'requests', 'flask-cors',
-                'psutil', 'jsonschema', 'onnx>=1.1.1', 'boto3', 'importlib2',
+                'psutil', 'jsonschema', 'onnx==1.1.1', 'boto3', 'importlib2',
                 'fasteners']
 # Enable Cu90 only when using linux with cuda enabled
 gpu_platform = False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ONNX new version broke a merge since onnx 1.2 has protobuf dependency issues
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
