### PR TITLE
Add CI buildspec for pull request.

### DIFF
--- a/ci/buildspec_pr.yml
+++ b/ci/buildspec_pr.yml
@@ -1,0 +1,26 @@
+# Build Spec for AWS CodeBuild CI
+
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - apt-get update
+      - apt-get install -y curl
+      - apt-get install -y libgfortran3
+      - pip install pip -U
+      - pip install flask
+      - pip install -U mxnet
+      - pip install Pillow
+      - pip install requests
+      - pip install flask-cors
+      - pip install fasteners
+      - pip install jsonschema
+      - pip install onnx -U
+      - pip install onnx-mxnet -U
+      - pip install -U -e .
+
+  build:
+    commands:
+      - python -m pytest mms/tests/unit_tests
+      - pylint -rn --rcfile=./mms/tests/pylintrc mms/.


### PR DESCRIPTION
*Issue #, if available:*

Remove integration_tests from pr build, only keep it in nightly build.
Building protobuf is no longer needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
