### PR TITLE
Bumping up the test coverage further

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,27 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+    if __name__ == "__main__" :
+
+[run]
+branch = True
+omit = */__init__.py
+       mms/tests/*
+       mms/utils/model_server_error_codes.py
+       mms/utils/timeit_decorator.py
+       mms/storage.py
+       mms/metrics/system_metrics.py
+       mms/utils/mxnet/*
+       mms/examples/metric_push_example.py
+       mms/model_service/*

--- a/mms/tests/README.md
+++ b/mms/tests/README.md
@@ -22,6 +22,12 @@ You can run the unit tests with the following:
 ```bash
 python -m pytest mms/tests/unit_tests/
 ```
+
+To get the coverage report of unit tests, you can run :
+
+```bash
+python -m pytest --cov-report  term-missing --cov=mms/ --ignore mms/tests/integration_tests/
+```
 ## CI Tests
 
 You can run the integration tests with the following:

--- a/mms/tests/unit_tests/test_utils/test_codec_helpers.py
+++ b/mms/tests/unit_tests/test_utils/test_codec_helpers.py
@@ -1,12 +1,14 @@
-import unittest
 import base64
 import pytest
+from mock import Mock
+import binascii
 from mms.mxnet_model_service_error import MMSError
-
+from mms.utils.model_server_error_codes import ModelServerErrorCodes as err
 from mms.utils.codec_helpers.codec import ModelWorkerCodecHelper
 
 
-class TestMXNetImageUtils(unittest.TestCase):
+class TestMXNetImageUtils():
+
     def test_model_worker_encoder(self):
         msg = b"Hello World!!"
         assert base64.b64encode(msg).decode('utf-8') == ModelWorkerCodecHelper.encode_msg(u'base64', msg), \
@@ -16,3 +18,36 @@ class TestMXNetImageUtils(unittest.TestCase):
         msg = b"Hello World!!"
         with pytest.raises(MMSError):
             ModelWorkerCodecHelper.encode_msg('dummy', msg)
+
+    class TestDecodeMsg():
+        encoded_msg = "SGVsbG8gV29ybGQh"
+
+        def test_decode_msg(self):
+            assert b"Hello World!" == ModelWorkerCodecHelper.decode_msg('base64', self.encoded_msg)
+
+        def test_with_no_encoding(self):
+            assert self.encoded_msg == ModelWorkerCodecHelper.decode_msg('garbage', self.encoded_msg)
+
+        def test_with_error(self, mocker):
+            b64_mock = mocker.patch('base64.b64decode')
+            exception = binascii.Error('error')
+            b64_mock.side_effect = exception
+
+            with pytest.raises(Exception) as ex:
+                ModelWorkerCodecHelper.decode_msg('base64', self.encoded_msg)
+
+            assert isinstance(ex.value, MMSError)
+            assert ex.value.get_code() == err.DECODE_FAILED
+            assert ex.value.get_message() == "base64 decode error {}".format(repr(exception))
+
+        def test_with_type_error(self, mocker):
+            b64_mock = mocker.patch('base64.b64decode')
+            exception = TypeError('error')
+            b64_mock.side_effect = exception
+
+            with pytest.raises(Exception) as ex:
+                ModelWorkerCodecHelper.decode_msg('base64', self.encoded_msg)
+
+            assert isinstance(ex.value, MMSError)
+            assert ex.value.get_code() == err.DECODE_FAILED
+            assert ex.value.get_message() == "base64 decode error {}".format(repr(exception))

--- a/mms/utils/codec_helpers/codec.py
+++ b/mms/utils/codec_helpers/codec.py
@@ -29,7 +29,7 @@ class ModelWorkerCodecHelper(object):
 
             return msg
         except (binascii.Error, TypeError) as e:
-            raise MMSError(err.DECODE_FAILED, "base64 decode error {}".format(e))
+            raise MMSError(err.DECODE_FAILED, "base64 decode error {}".format(repr(e)))
 
     @staticmethod
     def encode_msg(encoding, msg):


### PR DESCRIPTION
1. Added test cases for codec.py
2. Added .coveragearc file to check the code coverage metrics only for the backend files. 

The command to run it is : (from the root project folder)

```py.test --cov-report  term-missing --cov=mms/ --ignore mms/tests/integration_tests/```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
