### PR TITLE
Fix for Legacy Manifest handling issue

### DIFF
--- a/mms/model_loader.py
+++ b/mms/model_loader.py
@@ -18,6 +18,7 @@ from mms.log import get_logger
 logger = get_logger()
 
 MANIFEST_FILENAME = 'MANIFEST.json'
+MANIFEST_LEGACY_FILE = 'MANIFEST.legacy'
 
 
 class ModelLoader(object):
@@ -43,10 +44,21 @@ class ModelLoader(object):
         """
         manifest = None
         manifest_file = os.path.join(model_dir, MANIFEST_FILENAME)
+
+        # Legacy manifest handling
+        manifest_legacy = None
+        manifest_legacy_file = os.path.join(model_dir, MANIFEST_LEGACY_FILE)
+
+        if os.path.isfile(manifest_legacy_file):
+            try:
+                manifest_legacy = json.load(open(manifest_legacy_file))
+            except ValueError as e:
+                raise Exception('Failed to open legacy manifest file. Stacktrace : ' + repr(e))
+
         if os.path.isfile(manifest_file):
             try:
                 manifest = json.load(open(manifest_file))
-            except Exception as e:
+            except ValueError as e:
                 raise Exception('Failed to open manifest file. Stacktrace: ' + str(e))
             model = manifest['model']
             engine = manifest['engine']
@@ -72,4 +84,4 @@ class ModelLoader(object):
             # TODO: search PYTHONPATH and MODELPATH for handler file
             raise Exception("handler file not not found: {}.".format(handler_file))
 
-        return manifest, handler_file
+        return manifest, manifest_legacy, handler_file

--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -306,10 +306,10 @@ class MXNetModelServiceWorker(object):
             if u'gpu' in data:
                 gpu = int(data[u'gpu'])
 
-            manifest, service_file_path = ModelLoader.load(model_dir, handler)
+            manifest, manifest_legacy, service_file_path = ModelLoader.load(model_dir, handler)
 
             self.service_manager.register_and_load_modules(model_name, model_dir, manifest,
-                                                           service_file_path, gpu, batch_size)
+                                                           service_file_path, gpu, batch_size, manifest_legacy)
         except ValueError as v:
             raise MMSError(err.VALUE_ERROR_WHILE_LOADING, "{}".format(v))
         except MMSError as m:

--- a/mms/service_manager.py
+++ b/mms/service_manager.py
@@ -98,7 +98,8 @@ class ServiceManager(object):
             for model_name in model_names
         }
 
-    def load_model(self, model_name, model_dir, manifest, model_service_class_def, gpu=None, batch_size=None):
+    def load_model(self, model_name, model_dir, manifest, model_service_class_def, gpu=None, batch_size=None,
+                   manifest_legacy=None):
         """
         Load a single model into a model service by using
         user passed Model Service Class Definitions.
@@ -118,7 +119,12 @@ class ServiceManager(object):
             If it is not set, cpu will be used.
         batch_size : int
             batch size
+        manifest_legacy: string
+            The legacy manifest string
         """
+        # Check which manifest to pass down
+        manifest = manifest if manifest_legacy is None else manifest_legacy
+
         model_service = model_service_class_def(model_name, model_dir, manifest, gpu)
         model_service._init_internal(model_name, model_dir, manifest, gpu, batch_size)
         self.loaded_modelservices[model_name] = model_service
@@ -200,7 +206,8 @@ class ServiceManager(object):
 
         return self.get_modelservices_registry(modelservice_names)
 
-    def register_and_load_modules(self, model_name, model_dir, manifest, module_file_path, gpu, batch_size):
+    def register_and_load_modules(self, model_name, model_dir, manifest, module_file_path, gpu, batch_size,
+                                  manifest_legacy=None):
         """
         Register all the modules and load them. This is a wrapper method around register_module and load_models.
         :param model_name
@@ -208,7 +215,8 @@ class ServiceManager(object):
         :param manifest
         :param module_file_path:
         :param gpu:
-        :param batch_size
+        :param batch_size:
+        :param manifest_legacy
         :return:
         """
 
@@ -229,4 +237,4 @@ class ServiceManager(object):
         registered_models = self.get_registered_modelservices()
         model_class_defn = registered_models[model_class_name]
 
-        self.load_model(model_name, model_dir, manifest, model_class_defn, gpu, batch_size)
+        self.load_model(model_name, model_dir, manifest, model_class_defn, gpu, batch_size, manifest_legacy)

--- a/mms/tests/unit_tests/test_model_loader.py
+++ b/mms/tests/unit_tests/test_model_loader.py
@@ -146,6 +146,7 @@ class TestModelLoad():
         empty_file(manifest_valid_data['model']['symbolFile'])
         empty_file(os.path.join(model_dir_path, handler_file))
 
-        manifest_return, handler_file_return = ModelLoader.load(model_dir_path, handler_file)
+        manifest_return, manifest_legacy_file, handler_file_return = ModelLoader.load(model_dir_path, handler_file)
         assert manifest_return == manifest_valid_data
         assert str(handler_file_return) == str(os.path.join(model_dir_path, handler_file))
+        assert manifest_legacy_file is None

--- a/mms/tests/unit_tests/test_model_service_worker.py
+++ b/mms/tests/unit_tests/test_model_service_worker.py
@@ -475,7 +475,7 @@ class TestMXNetModelServiceWorker:
                 mocker.patch('mms.model_service_worker.ModelWorkerMessageValidators.validate_load_message'),
                 mocker.patch('mms.model_service_worker.ModelLoader.load')
             )
-            patches.loader.return_value = 'testmanifest', 'test_service_file_path'
+            patches.loader.return_value = 'testmanifest', 'testmanifestlegacy', 'test_service_file_path'
             return patches
 
         @pytest.fixture()
@@ -513,7 +513,7 @@ class TestMXNetModelServiceWorker:
             if gpu[0]:
                 data[u'gpu'] = gpu[0]
             worker.load_model(data)
-            worker.service_manager.register_and_load_modules.assert_called_once_with('name', 'mpath', 'testmanifest', 'test_service_file_path', gpu[1], batch_size[1])
+            worker.service_manager.register_and_load_modules.assert_called_once_with('name', 'mpath', 'testmanifest', 'test_service_file_path', gpu[1], batch_size[1], 'testmanifestlegacy')
 
         def test_success(self, patches, worker):
             msg, code = worker.load_model(self.data)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added handling for reading Manifest.legacy file, if present and passing it if not None to custom service code's class def method. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
