### PR TITLE
Fixed issue where we try to load multiple models concurrently

### DIFF
--- a/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/ModelArchive.java
+++ b/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/ModelArchive.java
@@ -269,7 +269,7 @@ public class ModelArchive {
         try {
             if (copyOnMigrate) {
                 File tmpDir = FileUtils.getTempDirectory();
-                File copyDir = new File(tmpDir, "models/" + manifest.getModel().getModelName());
+                File copyDir = new File(tmpDir, "models/" + modelDir.getName());
                 FileUtils.deleteDirectory(copyDir);
                 FileUtils.forceMkdir(copyDir);
                 FileUtils.copyDirectory(modelDir, copyDir, f -> !f.isHidden());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now we will use model name from the modelDir instead of manifest file.

Thanks to @frankfliu for suggesting the fix! 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
