### PR TITLE
Fix Backend worker socket not honoring timeout

### DIFF
--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -178,7 +178,6 @@ class MXNetModelServiceWorker(object):
         """
         try:
             self.sock.settimeout(SOCKET_ACCEPT_TIMEOUT)
-            self.sock.setblocking(True)  # workaround error(35, 'Resource temporarily unavailable') on OSX
 
             if self.sock_type == 'unix':
                 self.sock.bind(self.sock_name)
@@ -202,6 +201,8 @@ class MXNetModelServiceWorker(object):
                     pr.disable()
                     pr.dump_stats('/tmp/mmsPythonProfile.prof')
                 (cl_socket, _) = self.sock.accept()
+                # workaround error(35, 'Resource temporarily unavailable') on OSX
+                cl_socket.setblocking(True)
                 if BENCHMARK:
                     pr.enable()
                 self.handle_connection(cl_socket)

--- a/mms/tests/unit_tests/test_model_service_worker.py
+++ b/mms/tests/unit_tests/test_model_service_worker.py
@@ -125,7 +125,7 @@ class TestSendResponse:
 
 # noinspection PyClassHasNoInit
 class TestRunServer:
-    accept_result = ('cl_sock', None)
+    accept_result = (mock.MagicMock(), None)
 
     def test_with_socket_bind_error(self, socket_patches, model_service_worker):
         bind_exception = socket.error("binding error")


### PR DESCRIPTION
*Issue #, if available:*
The issue was caused by the fact that
calling socket.setblocking(True) is equivalent to saying socket.settimeout(None)
So we need to set the timeout after setting the blocking flag.
reference
https://docs.python.org/2/library/socket.html
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
