### PR TITLE
Allow user to config log4j configuration in cli.

### DIFF
--- a/mms/arg_parser.py
+++ b/mms/arg_parser.py
@@ -37,12 +37,14 @@ class ArgParser(object):
                             dest='mms_config',
                             help='Configuration file for model server')
         parser.add_argument('--models',
-                            required=False,
                             metavar='MODEL_PATH1 MODEL_NAME=MODEL_PATH2...',
                             nargs='+',
                             help='Models to be loaded using [model_name=]model_location format. '
                                  'Location can be a HTTP URL, a model archive file or directory '
                                  'contains model archive files in MODEL_STORE.')
+        parser.add_argument('--log-config',
+                            dest='log_config',
+                            help='Log4j configuration file for model server')
         return parser
 
     @staticmethod

--- a/mms/model_server.py
+++ b/mms/model_server.py
@@ -47,10 +47,13 @@ def start():
                 os.remove(pid_file)
 
         mms_home = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-        cmd = ["java",
-               "-Dmodel_server_home={}".format(mms_home),
-               "-jar",
-               "{}/mms/frontend/model-server.jar".format(mms_home)]
+        cmd = ["java", "-Dmodel_server_home={}".format(mms_home)]
+        if args.log_config is not None:
+            cmd.append("-Dlog4j.configuration={}".format(args.log_config))
+
+        cmd.append("-jar")
+        cmd.append("{}/mms/frontend/model-server.jar".format(mms_home))
+
         if args.mms_config is not None:
             cmd.append("-f")
             cmd.append(args.mms_config)


### PR DESCRIPTION
*Issue #, if available:
MMS requires java -D option to configure log4j properties. We should make this available via cli.

*Description of changes:
Add command line options to config log4j properties.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
