### PR TITLE
Respect runtime configured in manifest.json

### DIFF
--- a/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/Manifest.java
+++ b/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/Manifest.java
@@ -33,7 +33,7 @@ public class Manifest {
         implementationVersion = "1.0";
         modelServerVersion = "1.0";
         license = "Apache 2.0";
-        runtime = RuntimeType.PYTHON2_7;
+        runtime = RuntimeType.PYTHON;
         model = new Model();
     }
 
@@ -240,10 +240,12 @@ public class Manifest {
     }
 
     public enum RuntimeType {
-        @SerializedName("python2.7")
-        PYTHON2_7("python2.7"),
-        @SerializedName("python3.6")
-        PYTHON3_6("python3.6");
+        @SerializedName("python")
+        PYTHON("python"),
+        @SerializedName("python2")
+        PYTHON2("python2"),
+        @SerializedName("python3")
+        PYTHON3("python3");
 
         String value;
 

--- a/frontend/modelarchive/src/test/java/com/amazonaws/ml/mms/archive/Exporter.java
+++ b/frontend/modelarchive/src/test/java/com/amazonaws/ml/mms/archive/Exporter.java
@@ -126,8 +126,9 @@ public final class Exporter {
                 }
             } else {
                 Manifest.RuntimeType runtimeType = manifest.getRuntime();
-                if (runtimeType == Manifest.RuntimeType.PYTHON2_7
-                        || runtimeType == Manifest.RuntimeType.PYTHON3_6) {
+                if (runtimeType == Manifest.RuntimeType.PYTHON
+                        || runtimeType == Manifest.RuntimeType.PYTHON2
+                        || runtimeType == Manifest.RuntimeType.PYTHON3) {
                     String[] tokens = handler.split(":");
                     File serviceFile = new File(modelPath, tokens[0]);
                     if (serviceFile.exists()) {

--- a/frontend/modelarchive/src/test/resources/models/noop-v1.0/MAR-INF/MANIFEST.json
+++ b/frontend/modelarchive/src/test/resources/models/noop-v1.0/MAR-INF/MANIFEST.json
@@ -4,7 +4,7 @@
   "description": "noop v1.0",
   "modelServerVersion": "1.0",
   "license": "Apache 2.0",
-  "runtime": "python2.7",
+  "runtime": "python",
   "model": {
     "modelName": "noop",
     "description": "no operation model",

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
@@ -58,7 +58,7 @@ public class WorkerLifeCycle {
 
         SocketAddress address = NettyUtils.getSocketAddress(port);
         String[] args = new String[6];
-        args[0] = "python";
+        args[0] = model.getModelArchive().getManifest().getRuntime().getValue();
         args[1] = new File(workingDir, "mms/model_service_worker.py").getAbsolutePath();
         args[4] = "--sock-type";
 

--- a/frontend/server/src/test/resources/management_open_api.json
+++ b/frontend/server/src/test/resources/management_open_api.json
@@ -218,8 +218,9 @@
             "schema": {
               "type": "string",
               "enum": [
-                "PYTHON2_7",
-                "PYTHON3_6"
+                "PYTHON",
+                "PYTHON2",
+                "PYTHON3"
               ]
             }
           },

--- a/model-archiver/model_archiver/arg_parser.py
+++ b/model-archiver/model_archiver/arg_parser.py
@@ -60,11 +60,11 @@ class ArgParser(object):
         parser_export.add_argument('--runtime',
                                    required=False,
                                    type=str,
-                                   default=RuntimeType.PYTHON2_7.value,
+                                   default=RuntimeType.PYTHON.value,
                                    choices=[s.value for s in RuntimeType],
                                    help='The runtime specifies which language to run your inference code on. '
                                         'The default runtime is {}. At the present moment we support the '
-                                        'following runtimes \n {}'.format(RuntimeType.PYTHON2_7, runtime_types))
+                                        'following runtimes \n {}'.format(RuntimeType.PYTHON, runtime_types))
 
         parser_export.add_argument('--export-path',
                                    required=False,

--- a/model-archiver/model_archiver/manifest_components/manifest.py
+++ b/model-archiver/model_archiver/manifest_components/manifest.py
@@ -16,8 +16,9 @@ from enum import Enum
 
 class RuntimeType(Enum):
 
-    PYTHON2_7 = "python2.7"
-    PYTHON3_6 = "python3.6"
+    PYTHON = "python"
+    PYTHON2 = "python2"
+    PYTHON3 = "python3"
 
     # TODO : Add more runtimes here when we support more runtimes such as Java/Go/Scala etc..
 

--- a/model-archiver/model_archiver/tests/unit_tests/test_model_packaging.py
+++ b/model-archiver/model_archiver/tests/unit_tests/test_model_packaging.py
@@ -34,7 +34,7 @@ class TestModelPackaging:
     export_path = '/Users/ghaipiyu/'
 
     args = Namespace(author=author, email=email, engine=engine, model_name=model_name, handler=handler,
-                     runtime=RuntimeType.PYTHON2_7.value, model_path=model_path, export_path=export_path, force=False)
+                     runtime=RuntimeType.PYTHON.value, model_path=model_path, export_path=export_path, force=False)
 
     @pytest.fixture()
     def patches(self, mocker):

--- a/model-archiver/model_archiver/tests/unit_tests/test_model_packaging_utils.py
+++ b/model-archiver/model_archiver/tests/unit_tests/test_model_packaging_utils.py
@@ -148,7 +148,7 @@ class TestExportModelUtils:
         handler = 'a.py::my-awesome-func'
 
         args = Namespace(author=author, email=email, engine=engine, model_name=model_name, handler=handler,
-                         runtime=RuntimeType.PYTHON2_7.value)
+                         runtime=RuntimeType.PYTHON.value)
 
         def test_publisher(self):
             pub = ModelExportUtils.generate_publisher(self.args)
@@ -167,7 +167,7 @@ class TestExportModelUtils:
         def test_manifest_json(self):
             manifest = ModelExportUtils.generate_manifest_json(self.args)
             manifest_json = json.loads(manifest)
-            assert manifest_json['runtime'] == RuntimeType.PYTHON2_7.value
+            assert manifest_json['runtime'] == RuntimeType.PYTHON.value
             assert 'engine' in manifest_json
             assert 'model' in manifest_json
             assert 'publisher' in manifest_json


### PR DESCRIPTION
*Issue #, if available:
Each worker should respect runtime configured in manifest

*Description of changes:
1. Respect runtime configured in manifest.json
2. Allow user define runtime as generic python, python2 or python3.
3. Update export tool and make python as default runtime.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
