### PR TITLE
Fixed Benchmark script runs for LSTM_PTB and RESNET-18

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -435,7 +435,7 @@ def run_benchmark():
 def modify_config_props_for_mms(pargs):
     shutil.copyfile(CONFIG_PROP_TEMPLATE, CONFIG_PROP)
     with open(CONFIG_PROP, 'a') as f:
-        f.write('\nnumber_of_netty_threads=32')
+        f.write('number_of_netty_threads=32')
         f.write('\njob_queue_size=1000')
         if pargs.gpus:
             f.write('\nnumber_of_gpu={}'.format(pargs.gpus[0]))


### PR DESCRIPTION
Tested locallly with the following command : 

```
python benchmarks/benchmark.py -l 10 -s --model lstm_ptb -w 8 -v
```

Output seen : 
```
Output available at /tmp/MMSBenchmark/out/throughput/lstm_ptb
Report generated at /tmp/MMSBenchmark/out/throughput/lstm_ptb/report/index.html
[{'throughput_lstm_ptb_Inference_Request_Average': 1129,
  'throughput_lstm_ptb_Inference_Request_Median': 968,
  'throughput_lstm_ptb_Inference_Request_Throughput': 71.7,
  'throughput_lstm_ptb_Inference_Request_aggregate_report_99_line': 3733,
  'throughput_lstm_ptb_Inference_Request_aggregate_report_error': '0.00%'}]

```
*Description of changes:*
The new line was causing an error while reading the property file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
