### PR TITLE
Fix crash when config.properties contains empty lines.

### DIFF
--- a/mms/model_server.py
+++ b/mms/model_server.py
@@ -117,8 +117,9 @@ def load_properties(file_path):
             line = line.strip()
             if not line.startswith("#"):
                 pair = line.split("=", 1)
-                key = pair[0].strip()
-                props[key] = pair[1]
+                if len(pair) > 1:
+                    key = pair[0].strip()
+                    props[key] = pair[1].strip()
 
     return props
 


### PR DESCRIPTION
mms/model_server did not check empty line when loading properties file.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
