### PR TITLE
Fix for Noop model runs on Benchmark scripts

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -53,7 +53,7 @@ JMX_GRAPHS_GENERATOR_PLAN = 'graphsGenerator.jmx'
 MODEL_RESNET_18 = 'resnet-18'
 MODEL_SQUEEZE_NET = 'squeezenet'
 MODEL_LSTM_PTB = 'lstm_ptb'
-MODEL_NOOP = 'noop'
+MODEL_NOOP = 'noop-v1.0'
 
 
 MODEL_MAP = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Corrected the model name in the script to run noop-v1.0. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
