### PR TITLE
Use python which MMS installed with to start metrics collector and mo…

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/metrics/MetricCollector.java
@@ -44,7 +44,7 @@ public class MetricCollector implements Runnable {
         try {
             // Collect System level Metrics
             String[] args = new String[2];
-            args[0] = "python";
+            args[0] = configManager.getPythonExecutable();
             args[1] = "mms/metrics/metric_collector.py";
             File workingDir = new File(configManager.getModelServerHome());
 

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -126,6 +126,11 @@ public final class ConfigManager {
         if (!prop.containsKey(NUMBER_OF_GPU)) {
             prop.setProperty(NUMBER_OF_GPU, String.valueOf(getAvailableGpu()));
         }
+
+        String pythonExecutable = args.getPythonExecutable();
+        if (pythonExecutable != null) {
+            prop.setProperty("PYTHON_EXECUTABLE", pythonExecutable);
+        }
     }
 
     public boolean isDebug() {
@@ -201,6 +206,10 @@ public final class ConfigManager {
         }
         mmsHome = getCanonicalPath(dir);
         return mmsHome;
+    }
+
+    public String getPythonExecutable() {
+        return prop.getProperty("PYTHON_EXECUTABLE", "python");
     }
 
     public String getModelStore() {
@@ -395,6 +404,7 @@ public final class ConfigManager {
     public static final class Arguments {
 
         private String mmsConfigFile;
+        private String pythonExecutable;
         private String modelStore;
         private String[] models;
 
@@ -402,6 +412,7 @@ public final class ConfigManager {
 
         public Arguments(CommandLine cmd) {
             mmsConfigFile = cmd.getOptionValue("mms-config-file");
+            pythonExecutable = cmd.getOptionValue("python");
             modelStore = cmd.getOptionValue("model-store");
             models = cmd.getOptionValues("models");
         }
@@ -416,6 +427,13 @@ public final class ConfigManager {
                             .desc("Path to the configuration properties file.")
                             .build());
             options.addOption(
+                    Option.builder("e")
+                            .longOpt("python")
+                            .hasArg()
+                            .argName("PYTHON")
+                            .desc("Python runtime executable path.")
+                            .build());
+            options.addOption(
                     Option.builder("m")
                             .longOpt("models")
                             .hasArgs()
@@ -425,7 +443,7 @@ public final class ConfigManager {
             options.addOption(
                     Option.builder("s")
                             .longOpt("model-store")
-                            .hasArgs()
+                            .hasArg()
                             .argName("MODELS-STORE")
                             .desc("Model store location where models can be loaded.")
                             .build());
@@ -434,6 +452,10 @@ public final class ConfigManager {
 
         public String getMmsConfigFile() {
             return mmsConfigFile;
+        }
+
+        public String getPythonExecutable() {
+            return pythonExecutable;
         }
 
         public void setMmsConfigFile(String mmsConfigFile) {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
@@ -12,6 +12,7 @@
  */
 package com.amazonaws.ml.mms.wlm;
 
+import com.amazonaws.ml.mms.archive.Manifest;
 import com.amazonaws.ml.mms.metrics.Metric;
 import com.amazonaws.ml.mms.util.ConfigManager;
 import com.amazonaws.ml.mms.util.NettyUtils;
@@ -85,7 +86,12 @@ public class WorkerLifeCycle {
 
         SocketAddress address = NettyUtils.getSocketAddress(port);
         String[] args = new String[6];
-        args[0] = model.getModelArchive().getManifest().getRuntime().getValue();
+        Manifest.RuntimeType runtime = model.getModelArchive().getManifest().getRuntime();
+        if (runtime == Manifest.RuntimeType.PYTHON) {
+            args[0] = configManager.getPythonExecutable();
+        } else {
+            args[0] = runtime.getValue();
+        }
         args[1] = new File(workingDir, "mms/model_service_worker.py").getAbsolutePath();
         args[4] = "--sock-type";
 

--- a/mms/model_server.py
+++ b/mms/model_server.py
@@ -4,6 +4,7 @@ File to define the entry point to Model Server
 
 import os
 import subprocess
+import sys
 import tempfile
 from builtins import str
 
@@ -80,6 +81,10 @@ def start():
 
         cmd.append("-jar")
         cmd.append("{}/mms/frontend/model-server.jar".format(mms_home))
+
+        # model-server.jar command line parameters
+        cmd.append("--python")
+        cmd.append(sys.executable)
 
         if args.mms_config:
             cmd.append("-f")


### PR DESCRIPTION
MetricsCollector depends psutil, which installed together with MMS.
MMS java code should use the same python to start metrics collector.

When start model service code, if generic python runtime is specified (default), we should try to use the same python where MMS installed as default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
