### PR TITLE
Edit pass on the main readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Model Server for Apache MXNet
 |---------|---------|
 | ![Python3 Build Status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoicGZ6dXFmMU54UGxDaGsxUDhXclJLcFpHTnFMNld6cW5POVpNclc4Vm9BUWJNamZKMGdzbk1lOU92Z0VWQVZJTThsRUttOW8rUzgxZ2F0Ull1U1VkSHo0PSIsIml2UGFyYW1ldGVyU3BlYyI6IkJJaFc1QTEwRGhwUXY1dDgiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master) | ![Python2 Build Status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiYVdIajEwVW9uZ3cvWkZqaHlaRGNUU2M0clE2aUVjelJranJoYTI3S1lHT3R5THJXdklzejU2UVM5NWlUTWdwaVVJalRwYi9GTnJ1aUxiRXIvTGhuQ2g0PSIsIml2UGFyYW1ldGVyU3BlYyI6IjArcHVCaFgvR1pTN1JoSG4iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master) |
 
-Apache MXNet Model Server (MMS) is a flexible and easy to use tool for serving deep learning models exported from [MXNet](http://mxnet.io/) or the Open Neural Network Exchange ([ONNX](http://onnx.ai/)).
+Model Server for Apache MXNet (MMS) is a flexible and easy to use tool for serving deep learning models exported from [MXNet](http://mxnet.io/) or the Open Neural Network Exchange ([ONNX](http://onnx.ai/)).
 
 
 Use the MMS Server CLI, or the pre-configured Docker images, to start a service that sets up HTTP endpoints to handle model inference requests.
@@ -15,42 +15,32 @@ A quick overview and examples for both serving and packaging are provided below.
 ## Contents of this Document
 * [Quick Start](#quick-start)
 * [Serve a Model](#serve-a-model)
-* [Create a Model Archive](#create-a-model-archive)
 * [Other Features](#other-features)
 * [Contributing](#contributing)
 
 ## Other Relevant Documents
 * [Latest Version Docs](docs/README.md)
 * [v0.4.0 Docs](https://github.com/awslabs/mxnet-model-server/blob/v0.4.0/docs/README.md)
+* [Migrating from v0.4.0 to v1.0.0](docs/migration.md)
 
 ## Quick Start
-### Pre-requisites
-Before proceeding further with this document, make sure you have the following.
-1. Python     - MXNet model server requires python to run the workers. 
+### Prerequisites
+Before proceeding further with this document, make sure you have the following prerequisites.
+1. Ubuntu, CentOS, or macOS. Windows support is experimental. The following instructions will focus on Linux and macOS only.
+1. Python     - MXNet model server requires python to run the workers.
 1. pip        - Pip is a python package management system.
-1. virtualenv (`optional`) - Virtualenv is used to create virtual python environments. You could install virtualenv after install pip as follows
-    ```bash
-    pip install virtualenv
-    ```
-    You could create a virtual environment as follows
-    ```bash
-    # Assuming we want to run python2.7 in /usr/local/bin/python2.7
-    virtualenv -p /usr/local/bin/python2.7 /tmp/pyenv2
-    # Enter this virtual environment as follows
-    source /tmp/pyenv2/bin/activate
-    ```
-1. Java 8     - MXNet Model Server requires Java 8 to start. You could install Java 8 as follows
-    For ubuntu:
+1. Java 8     - MXNet Model Server requires Java 8 to start. You have the following options for installing Java 8:
+    For Ubuntu:
     ```bash
     sudo apt-get install openjdk-8-jre-headless
     ```
-    
-    For centos:
+
+    For CentOS:
     ```bash
     sudo yum install java-1.8.0-openjdk
     ```
-    
-    For Mac:
+
+    For macOS:
     ```bash
     brew tap caskroom/versions
     brew update
@@ -59,21 +49,50 @@ Before proceeding further with this document, make sure you have the following.
 
 ### Installing MXNet Model Server with pip
 
-A minimal version of `model-archiver` will be installed with MMS as dependency. See [model-archiver](model-archiver/README.md) for more options and detail.
+#### Setup
 
-It's a good practice to run and install all python dependencies in virtual environments so as to have isolation of python environments and ease of dependency management. 
-We recommend installing and running MXNet Model Server in a virtual environment. 
+**Step 1:** Setup a Virtual Environment
+We recommend installing and running MXNet Model Server in a virtual environment. It's a good practice to run and install all of the Python dependencies in virtual environments. This will provide isolation of the dependencies and ease dependency management.
 
-MMS won't install mxnet engine by default, you can install mxnet-mkl or mxnet-cu90mkl based on your need to run MXNet Model Server on CPU host or on GPU host.
+One option is to use Virtualenv. This is used to create virtual Python environments. You may install and activate a `virtualenv` for Python 2.7 as follows:
+    ```bash
+    pip install virtualenv
+    ```
+    Then create a virtual environment:
+    ```bash
+    # Assuming we want to run python2.7 in /usr/local/bin/python2.7
+    virtualenv -p /usr/local/bin/python2.7 /tmp/pyenv2
+    # Enter this virtual environment as follows
+    source /tmp/pyenv2/bin/activate
+    ```
+Refer to the [Virtualenv documentation](https://virtualenv.pypa.io/en/stable/) for further information.
+
+**Step 2:** Install MXNet
+MMS won't install the MXNet engine by default. If it isn't already installed in your virtual environment, you must install one of the MXNet pip packages.
+
+For CPU inference, `mxnet-mkl` is recommended. Install it as follows:
 
 ```bash
-# Running MXNet Model Server on CPU hosts 
+# Recommended for running MXNet Model Server on CPU hosts
 pip install mxnet-mkl
+```
 
+For GPU inference, `mxnet-cu92mkl` is recommended. Install it as follows:
+
+```bash
+# Recommended for running MXNet Model Server on GPU hosts
+pip install mxnet-cu92mkl
+```
+
+**Step 3:** Install or Upgrade MMS as follows:
+
+```bash
 pip install -U mxnet-model-server
 ```
 
-See the [advanced installation](docs/install.md) page for more options and troubleshooting.
+**Notes:**
+* A minimal version of `model-archiver` will be installed with MMS as dependency. See [model-archiver](model-archiver/README.md) for more options and details.
+* See the [advanced installation](docs/install.md) page for more options and troubleshooting.
 
 ### Serve a Model
 
@@ -137,60 +156,16 @@ Other models can be downloaded from the [model zoo](docs/model_zoo.md), so try o
 Now you've seen how easy it can be to serve a deep learning model with MMS! [Would you like to know more?](docs/server.md)
 
 ### Stopping the running model server
-To stop the current running model-server instance, you could run the following command
+To stop the current running model-server instance, run the following command:
 ```bash
 $ mxnet-model-server --stop
 ```
-You would see an output specifying that the model-server running instance stopped.
+You would see output specifying that mxnet-model-server has stopped.
 
 ### Create a Model Archive
 
-MMS enables you to package up all of your model artifacts into a single model archive, that you can then easily share or distribute. To package a model, follow these **three** steps:
-
-**1. Download sample squeezenet model artifacts (if you don't have them handy)**
-
-```bash
-mkdir squeezenet
-cd squeezenet
-
-curl -O https://s3.amazonaws.com/model-server/model_archive_1.0/examples/squeezenet_v1.1/squeezenet_v1.1-symbol.json
-curl -O https://s3.amazonaws.com/model-server/model_archive_1.0/examples/squeezenet_v1.1/squeezenet_v1.1-0000.params
-curl -O https://s3.amazonaws.com/model-server/model_archive_1.0/examples/squeezenet_v1.1/signature.json
-curl -O https://s3.amazonaws.com/model-server/model_archive_1.0/examples/squeezenet_v1.1/synset.txt
-```
-
-The downloaded model artifact files are:
-
-* **Model Definition** (json file) - contains the layers and overall structure of the neural network
-* **Model Params and Weights** (params file) - contains the parameters and the weights
-* **Model Signature** (json file) - defines the inputs and outputs that MMS is expecting to hand-off to the API
-* **assets** (text files) - auxiliary files that support model inference such as vocabularies, labels, etc. and vary depending on the model
-
-Further details on these files, custom services, and advanced `model-archiver` features can be found on the [Package Models for Use with MMS](model-archiver/README.md) page.
-
-**2. Prepare your model custom service code**
-
-You can implement your own model customer service code as model archive entry point. Here we are going to use provided mxnet vision service model_service_template:
-
-```bash
-cp -r mxnet-model-server/examples/model_service_template/* squeezenet/
-``` 
-
-**3. Package Your Model**
-
-With the model artifacts available locally, you can use the `model-archiver` CLI to generate a `.mar` file that can be used to serve an inference API with MMS.
-
-In this next step we'll run `model-archiver` and tell it our model's prefix is `squeezenet_v1.1` with the `model-name` argument. Then we're giving it the `model-path` to the model's assets.
-
-**Note**: For mxnet models, `model-name` must match prefix of the symbol and param file name. 
-
-```bash
-model-archiver --model-name squeezenet_v1.1 --model-path squeezenet --handler mxnet_vision_service:handle
-```
-
-This will package all the model artifacts files in `squeezenet` directory and output `squeezenet_v1.1.mar` in the current working directory. This `.mar` file is all you need to run MMS, serving inference requests for a simple image recognition API. Go back to the Serve a Model tutorial above and try to run this model archive that you just created!
-
-To learn more about `model-archiver`, check out [Model archiver documentation](model-archiver/README.md)
+MMS enables you to package up all of your model artifacts into a single model archive. This makes it easy to share and deploy your models.
+To package a model, check out [model archiver documentation](model-archiver/README.md)
 
 ## Recommended production deployments
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,14 +27,14 @@ Running MXNet Model Server with Docker in two steps:
 
 **Step 1: Run the Docker image.**
 
-This will download the MMS Docker image and run its default configuration, serving a Squeezenet model.
+This will download the MMS Docker image and run its default configuration, serving a SqueezeNet model.
 
 ```bash
 docker run -itd --name mms -p 80:8080 -p 81:8081 awsdeeplearningteam/mms_cpu mxnet-model-server --start --models squeezenet=https://s3.amazonaws.com/model-server/models/squeezenet_v1.1/squeezenet_v1.1.model
 ```
 
-With the `-p` flag, we're setting it up so you can run inference on your host computer's port: `80` 
-and you can run other control plane API's on your host computer's port : `81`
+With the `-p` flag, we're setting it up so you can run the Predict API on your host computer's port `80`. This maps to the Docker image's port `8080`.
+It will run the Management API on your host computer's port `81`. This maps to the Docker image's port `8081`.
 
 **Step 2: Test inference.**
 
@@ -57,7 +57,7 @@ After fetching this image of a kitten and posting it to the `predict` endpoint, 
 
 ### Cleaning Up
 
-Now that you have tested it out, you can stop the Docker container. The following command with stop the server and delete the container, but retain the Docker image for trying out other models and configurations next.
+Now that you have tested it out, you may stop the Docker container. The following command will stop the server and delete the container. It will retain the Docker image for trying out other models and configurations later.
 
 ```bash
 docker rm -f mms
@@ -65,11 +65,14 @@ docker rm -f mms
 
 ## Configuring MMS with Docker
 
-In the Quickstart section, you launched a Docker image with MMS serving the Squeezenet model. Now you will learn how to configure MMS with Docker to run other models, as well as how to collect MMS logs, and optimize your MMS with Docker images.
+In the Quickstart section, you launched a Docker image with MMS serving the SqueezeNet model.
+Now you will learn how to configure MMS with Docker to run other models.
+You will also learn how to collect MMS logs, and optimize MMS with Docker images.
 
 ### Using MMS and Docker with a Shared Volume
 
-For the purpose of loading different models and/or running the container with a different configuration MMS you will setup a shared volume with the Docker image.
+You may sometimes want to load different models with a different configuration.
+Setting up a shared volume with the Docker image is the recommended way to handle this.
 
 **Step 1: Create a folder to share with the Docker container.**
 
@@ -86,7 +89,7 @@ Download the template `config.properties` and place it in the `models` folder yo
 
 **Step 3: Modify the configuration template.**
 
-Edit the file you downloaded, `config.properties`. 
+Edit the file you downloaded, `config.properties`.
 
 ```properties
 # vmargs=-Xmx1g -XX:MaxDirectMemorySize=512m -Dlog4j.configuration=file:///opt/ml/conf/log4j.properties
@@ -111,14 +114,15 @@ Save the file.
 
 **Step 4: Run MMS with Docker using a shared volume.**
 
-When you run the following command, the `-v` argument and path values of `/tmp/models/:/models` will map the `models` folder you created (assuming it was in ) with a folder inside the Docker container. MMS will then be able to use the local model file.
+When you run the following command, the `-v` argument and path values of `/tmp/models/:/models` will map the Docker image's `models` folder to your local `/tmp/models` folder.
+MMS will then be able to use the local model file.
 
 ```bash
 docker run -itd --name mms -p 80:8080 -p 81:8081 -v /tmp/models/:/models awsdeeplearningteam/mms_cpu mxnet-model-server --start --mms-config /models/config.properties --models resnet=https://s3.amazonaws.com/model-server/models/resnet-18/resnet-18.model
 ```
 
-**NOTE**: If you modify the inference_address or the management_address in the configuration file, accordingly modify the 
-ports exposed by docker as well.
+**NOTE**: If you modify the inference_address or the management_address in the configuration file,
+you must modify the ports exposed by Docker as well.
 
 **Step 5: Test inference.**
 
@@ -141,7 +145,11 @@ Given that this is a different model, the same image yields a different inferenc
 ...
 ```
 
-Now that you have tried the default inference using Squeezenet and configuring inference to the resnet-18 model you are ready to try some other more advanced settings.
+## Conclusion
+
+You have tried the default Predictions API settings using a SqueezeNet model. 
+You then configured your Predictions API endpoints to also serve a ResNet-18 model.
+Now you are ready to try some other more **advanced settings** such as:
 
 * GPU inference
 * MMS settings

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Basic Features
 * [Serving Quick Start](../README.md#serve-a-model) - Basic server usage tutorial
-* [Model archive Quick Start](../README.md#create-a-model-archive) - Tutorial that shows you how to package a model archive file.
+* [Model Archive Quick Start](../model-archive/README.md#creating-a-model-archive) - Tutorial that shows you how to package a model archive file.
 * [Installation](install.md) - Installation procedures and troubleshooting
 * [Serving Models](server.md) - Explains how to use `mxnet-model-server`.
   * [REST API](rest_api.md) - Specification on the API endpoint for MMS

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# MMS Examples
+
+The following are examples on how to create and serve model archives with MMS.
+
+* Gluon Models
+    * [AlexNet](gluon_alexnet) - train a custom Gluon model, use model archiver, then serve the model archive with MMS
+    * [Character CNN](gluon_character_cnn) - download a pre-trained model that classifies product reviews, use model archiver, then serve the model archive with MMS
+
+* Symbolic Models 
+  * [Image Classification with SqueezeNet](mxnet_vision) - download a pre-trained computer vision model, use model archiver, then serve the model archive with MMS
+  * [LSTM with PTB](lstm_ptb) - download a pre-trained LSTM model that generates text, use model archiver, then serve the model archive with MMS
+
+* [How to setup metrics collection with AWS CloudWatch](metrics_cloudwatch)


### PR DESCRIPTION
*Description of changes:*
This PR: 
* moves the archiver "quickstart" to the archiver docs as the tutorial requires the user to download the source code.
* clarifies steps
* fixes spelling and grammar
* adds a readme to the examples folder

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
