### PR TITLE
Always use utf-8 to decode bytes.

### DIFF
--- a/mms/model_service/model_service.py
+++ b/mms/model_service/model_service.py
@@ -116,7 +116,7 @@ class ModelService(object):
         if input_type == "application/json":
             # user might not send content in HTTP request
             if isinstance(form_data, (bytes, bytearray)):
-                form_data = ast.literal_eval(form_data.decode())
+                form_data = ast.literal_eval(form_data.decode("utf-8"))
 
         input_data.append(form_data)
 

--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -75,9 +75,9 @@ class MXNetModelServiceWorker(object):
         :param load_model_request:
         :return:
         """
-        model_dir = load_model_request["modelPath"].decode()
-        model_name = load_model_request["modelName"].decode()
-        handler = load_model_request["handler"].decode()
+        model_dir = load_model_request["modelPath"].decode("utf-8")
+        model_name = load_model_request["modelName"].decode("utf-8")
+        handler = load_model_request["handler"].decode("utf-8")
         batch_size = None
         if "batchSize" in load_model_request:
             batch_size = int(load_model_request["batchSize"])

--- a/mms/protocol/otf_message_handler.py
+++ b/mms/protocol/otf_message_handler.py
@@ -107,7 +107,7 @@ def create_load_model_response(code, message):
     msg = bytearray()
     msg += struct.pack('!i', code)
 
-    buf = message.encode()
+    buf = message.encode("utf-8")
     msg += struct.pack('!i', len(buf))
     msg += buf
     msg += struct.pack('!i', -1)  # no predictions
@@ -254,19 +254,19 @@ def _retrieve_input_data(conn):
         return None
 
     model_input = dict()
-    model_input["name"] = _retrieve_buffer(conn, length).decode()
+    model_input["name"] = _retrieve_buffer(conn, length).decode("utf-8")
 
     length = _retrieve_int(conn)
-    content_type = _retrieve_buffer(conn, length).decode()
+    content_type = _retrieve_buffer(conn, length).decode("utf-8")
     model_input["contentType"] = content_type
 
     length = _retrieve_int(conn)
     value = _retrieve_buffer(conn, length)
 
     if content_type == "application/json":
-        model_input["value"] = json.loads(value.decode())
+        model_input["value"] = json.loads(value.decode("utf-8"))
     elif content_type.startswith("text"):
-        model_input["value"] = value.decode()
+        model_input["value"] = value.decode("utf-8")
     else:
         model_input["value"] = value
 

--- a/mms/service.py
+++ b/mms/service.py
@@ -63,7 +63,7 @@ class Service(object):
 
         input_batch = []
         for batch_idx, request_batch in enumerate(batch):
-            req_id = request_batch.get('requestId').decode()
+            req_id = request_batch.get('requestId').decode("utf-8")
             parameters = request_batch['parameters']
 
             model_in = dict()

--- a/mms/tests/unit_tests/test_otf_codec_protocol.py
+++ b/mms/tests/unit_tests/test_otf_codec_protocol.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -8,6 +10,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+
 """
 On The Fly Codec tester
 """
@@ -17,6 +20,7 @@ from collections import namedtuple
 import pytest
 
 import mms.protocol.otf_message_handler as codec
+from builtins import bytes
 
 
 @pytest.fixture()
@@ -104,7 +108,7 @@ class TestOtfCodecHandler:
             "requestId": b"request_id", "headers": [], "parameters": [
                 {"name": "input_name",
                  "contentType": "text/plain",
-                 "value": "text_value"
+                 "value": u"text_value测试"
                  }
             ]
         }]
@@ -115,7 +119,7 @@ class TestOtfCodecHandler:
             b"\xFF\xFF\xFF\xFF",
             b"\x00\x00\x00\x0a", b"input_name",
             b"\x00\x00\x00\x0a", b"text/plain",
-            b"\x00\x00\x00\x0a", b"text_value",
+            b"\x00\x00\x00\x0a", bytes(u"text_value测试", "utf-8"),
             b"\xFF\xFF\xFF\xFF",  # end of parameters
             b"\xFF\xFF\xFF\xFF"  # end of batch
         ]


### PR DESCRIPTION
Tested with following command:

curl -k -X POST https://127.0.0.1:8443/predictions/noop -H "Content-Type: application/json" -d '[{"input_sentence": "好 the exchange floor as soon as ual stopped trading we <unk> for a panic said one top floor trader"}]'

This will fail before the fix and now is working fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
