### PR TITLE
Send metrics object during model load time

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/metrics/Metric.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/metrics/Metric.java
@@ -23,7 +23,7 @@ public class Metric {
 
     private static final Pattern PATTERN =
             Pattern.compile(
-                    "\\s*(\\w+)\\.(\\w+):([0-9\\-,.]+)\\|#([^|]*)\\|#hostname:([^,]+),([^,]+)(,(.*))?");
+                    "\\s*(\\w+)\\.(\\w+):([0-9\\-,.e]+)\\|#([^|]*)\\|#hostname:([^,]+),([^,]+)(,(.*))?");
 
     @SerializedName("MetricName")
     private String metricName;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Custom metrics are needed even while scaling up and down the workers. This change accomodates for that.


## Output seen after loading the model which generates some dummy metrics
```
HostName=hostName
RequestId=72333ff8-37c3-44a3-ac70-62418d72cf36
Marketplace=MXNetModelServer:Unknown:UK
StartTime=1542391522
Program=MXNetModelServer
Metrics=DUMMYInferenceTime=0.06447577476501465 Milliseconds ModelName|squeezenet  Level|Model
EOE
HostName=hostName
RequestId=72333ff8-37c3-44a3-ac70-62418d72cf36
Marketplace=MXNetModelServer:Unknown:UK
StartTime=1542391522
Program=MXNetModelServer
Metrics=DUMMYSize=1000 Megabytes ModelName|squeezenet  Level|Model
EOE
HostName=hostName
RequestId=72333ff8-37c3-44a3-ac70-62418d72cf36
Marketplace=MXNetModelServer:Unknown:UK
StartTime=1542391522
Program=MXNetModelServer
Metrics=DUMMYPercent=90.9 Percent ModelName|squeezenet  Level|Model
EOE
HostName=hostName
RequestId=72333ff8-37c3-44a3-ac70-62418d72cf36
Marketplace=MXNetModelServer:Unknown:UK
StartTime=1542391522
Program=MXNetModelServer
Metrics=DUMMYCounter=20 Count ModelName|squeezenet  Level|Model
EOE
```

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
