### PR TITLE
Redo batching

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -130,7 +130,7 @@ public class WorkerThread implements Runnable {
             connect();
 
             while (isRunning()) {
-                req = aggregator.getRequest(workerId);
+                req = aggregator.getRequest(workerId, state);
 
                 backendChannel.writeAndFlush(req).sync();
 


### PR DESCRIPTION
*Issue #, if available:*

Redo batching. 

*Description of changes:*

Saw the following results for LSTM with batchsize of 5 and maximum delay of 100ms

## Without changes
| Concurrency | TPS | P50 | P90 | P99 |
| ---------        | ---  | ---   | ---   | ---   |
| 5 | 49.04 | 105 | 106 | 110 |
| 8  | 79.41 | 105 | 107 | 110 |
| 10 | 105.44 | 105 | 107 | 108 |
| 25 | 1808.73 | 10 | 20 | 106 |
| 50 | 6072.04 | 7 | 9 | 51 |

## With changes
| Concurrency | TPS | P50 | P90 | P99 | P100 |
| ---------        | ---  | ---   | ---   | ---   | ---- |
| 5 | 810.55 | 6 | 6 | 8 | 37 |
| 8  | 840.93 | 11 | 12 | 15 | 26 |
| 10 | 1649.30 | 6 | 6 | 9 | 12 |
| 25 | 4225.86 | 6 | 6 | 9 | 16 |
| 50 | 6163.47 | 8 | 10 | 31 | 39 |

* I have seen variation of +- 5% in each run . I ran `ab` test 3 times and took the middle value result. 
* Varying concurrency levels (5, 8, 10, 25, 50) with 5000 messages for the above two experiments. 100 concurrent requests also showed similar results as 50 so did not test further.

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
