### PR TITLE
Fix onnx installation comment

### DIFF
--- a/model-archiver/model_archiver/model_packaging_utils.py
+++ b/model-archiver/model_archiver/model_packaging_utils.py
@@ -125,7 +125,7 @@ class ModelExportUtils(object):
         try:
             import onnx
         except ImportError:
-            raise ModelArchiverError("Onnx package is not installed. Run command: pip install mxnet to install it.")
+            raise ModelArchiverError("Onnx package is not installed. Run command: pip install onnx to install it.")
 
         symbol_file = '%s-symbol.json' % model_name
         params_file = '%s-0000.params' % model_name


### PR DESCRIPTION
*Description of changes:*
`pip install mxnet` doesn't help to fix the following error.
```
$ model-archiver --model-name onnx-squeezenet --model-path onnx-squeezenet --handler mxnet_vision_service:handle
ERROR - Onnx package is not installed. Run command: pip install mxnet to install it.
```
`pip install onnx` is correct package to install

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
