### PR TITLE
Fix typos

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -11,7 +11,7 @@
 
 MXNet Model Server can be used for many types of inference in production settings. It provides an easy-to-use command line interface and utilizes  [REST based APIs](rest_api.md) handle state prediction requests. Support for models from a wide range of deep learning frameworks is achieved through its [ONNX model](https://onnx.ai) export feature.
 
-For example, you want to make an app that lets your users snap a picture, and it will tell them what what objects were detected in the scene and predictions on what the objects might be. You can use MMS to serve a prediction endpoint for a object detection and identification model that intakes images, then returns predictions. You can also modify MMS behavior with custom services and run multiple models. There are examples of custom services in the [examples](../examples) folder.
+For example, you want to make an app that lets your users snap a picture, and it will tell them what objects were detected in the scene and predictions on what the objects might be. You can use MMS to serve a prediction endpoint for a object detection and identification model that intakes images, then returns predictions. You can also modify MMS behavior with custom services and run multiple models. There are examples of custom services in the [examples](../examples) folder.
 
 ## Technical Details
 

--- a/model-archiver/docs/convert_from_onnx.md
+++ b/model-archiver/docs/convert_from_onnx.md
@@ -95,7 +95,7 @@ Now start the server:
 ```bash
 cd mxnet-model-server
 
-mxnet-model-server --start --model-store examples --models squeezenet=squeezenet_v1.1.mar
+mxnet-model-server --start --model-store examples --models squeezenet=onnx-squeezenet.mar
 ```
 
 After your server starts, you can use the following command to see the prediction results.


### PR DESCRIPTION
*Description of changes:*
- Fix typos
- output of `model-archiver --model-name onnx-squeezenet --model-path onnx-squeezenet --handler mxnet_vision_service:handle` is onnx-squeezenet.mar, not squeezenet_v1.1.mar

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
