### PR TITLE
Remove extra character in command

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -43,7 +43,7 @@ It will run the Management API on your host computer's port `8081`. This maps to
 
 ```bash
 curl -O https://s3.amazonaws.com/model-server/inputs/kitten.jpg
-curl -X POST http://127.0.0.1/predictions/squeezenet -T @kitten.jpg
+curl -X POST http://127.0.0.1/predictions/squeezenet -T kitten.jpg
 ```
 
 After fetching this image of a kitten and posting it to the `predict` endpoint, you should see a response similar to the following:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The curl command wasn't working on Mac OS X until I removed the '@' symbol.

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
