### PR TITLE
Fix minor mms startup bug.

### DIFF
--- a/mms/model_server.py
+++ b/mms/model_server.py
@@ -26,6 +26,7 @@ def start():
         with open(pid_file, "r") as f:
             pid = int(f.readline())
 
+    # pylint: disable=too-many-nested-blocks
     if args.stop:
         if pid is None:
             print("Model server is not currently running.")
@@ -74,11 +75,20 @@ def start():
             if not os.path.isfile(args.mms_config):
                 print("--mms-config file not found: {}".format(args.mms_config))
                 exit(1)
+            mms_conf_file = args.mms_config
+        else:
+            mms_conf_file = "config.properties"
 
-            props = load_properties(args.mms_config)
+        if os.path.isfile(mms_conf_file):
+            props = load_properties(mms_conf_file)
             vm_args = props.get("vmargs")
             if vm_args:
-                cmd.extend(vm_args.split())
+                arg_list = vm_args.split()
+                if args.log_config:
+                    for word in arg_list[:]:
+                        if word.startswith("-Dlog4j.configuration="):
+                            arg_list.remove(word)
+                cmd.extend(arg_list)
 
         cmd.append("-jar")
         cmd.append("{}/mms/frontend/model-server.jar".format(mms_home))


### PR DESCRIPTION
1. vm_args is ignored if --mms-config is not passed to startup script
2. duplicate -Dlog4j.properties if both vm_args and --log-config is defined.

Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
