### PR TITLE
Configurable response buffer size

### DIFF
--- a/docker/advanced_settings.md
+++ b/docker/advanced_settings.md
@@ -307,6 +307,7 @@ Notes on a couple of the parameters:
 * **keystore_type** - Store of cryptographic keys and certificates
 * **private_key_file** - Location of the private key file
 * **certificate_file** - Location of the certificate file
+* **backend_response_buffer_size** - The maximum buffer size the frontend allocates for a worker response, in bytes.
 
 in the range of 0 .. (num-gpu-1) in a round-robin fashion. **By default MMS uses all the available GPUs but this parameter can be configured if user want to use only few of them**.
 
@@ -325,4 +326,5 @@ in the range of 0 .. (num-gpu-1) in a round-robin fashion. **By default MMS uses
 # keystore_type=PKCS12
 # private_key_file=src/test/resources/key.pem
 # certificate_file=src/test/resources/certs.pem
+# backend_response_buffer_size=6553500
 ```

--- a/docker/advanced_settings.md
+++ b/docker/advanced_settings.md
@@ -326,5 +326,5 @@ in the range of 0 .. (num-gpu-1) in a round-robin fashion. **By default MMS uses
 # keystore_type=PKCS12
 # private_key_file=src/test/resources/key.pem
 # certificate_file=src/test/resources/certs.pem
-# backend_response_buffer_size=6553500
+# max_response_size=6553500
 ```

--- a/docker/advanced_settings.md
+++ b/docker/advanced_settings.md
@@ -307,7 +307,7 @@ Notes on a couple of the parameters:
 * **keystore_type** - Store of cryptographic keys and certificates
 * **private_key_file** - Location of the private key file
 * **certificate_file** - Location of the certificate file
-* **backend_response_buffer_size** - The maximum buffer size the frontend allocates for a worker response, in bytes.
+* **max_response_size** - The maximum buffer size the frontend allocates for a worker response, in bytes.
 
 in the range of 0 .. (num-gpu-1) in a round-robin fashion. **By default MMS uses all the available GPUs but this parameter can be configured if user want to use only few of them**.
 

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -86,6 +86,8 @@ public final class ConfigManager {
     private static final String CERTIFICATE_FILE = "certificate_file";
     private static final String PRIVATE_KEY_FILE = "private_key_file";
 
+    private static final String BACKEND_RESPONSE_BUFFER_SIZE = "backend_response_buffer_size";
+
     private Pattern blacklistPattern;
     private Properties prop;
 
@@ -418,6 +420,10 @@ public final class ConfigManager {
 
     public int getIoRatio() {
         return getIntProperty(IO_RATIO, 50);
+    }
+
+    public int getBackendResponseBufferSize() {
+        return getIntProperty(BACKEND_RESPONSE_BUFFER_SIZE, 6553500);
     }
 
     void setProperty(String key, String value) {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -86,7 +86,7 @@ public final class ConfigManager {
     private static final String CERTIFICATE_FILE = "certificate_file";
     private static final String PRIVATE_KEY_FILE = "private_key_file";
 
-    private static final String BACKEND_RESPONSE_BUFFER_SIZE = "backend_response_buffer_size";
+    private static final String MAX_RESPONSE_SIZE = "max_response_size";
 
     private Pattern blacklistPattern;
     private Properties prop;
@@ -422,8 +422,8 @@ public final class ConfigManager {
         return getIntProperty(IO_RATIO, 50);
     }
 
-    public int getBackendResponseBufferSize() {
-        return getIntProperty(BACKEND_RESPONSE_BUFFER_SIZE, 6553500);
+    public int getMaxResponseSize() {
+        return getIntProperty(MAX_RESPONSE_SIZE, 6553500);
     }
 
     void setProperty(String key, String value) {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/codec/ModelResponseDecoder.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/codec/ModelResponseDecoder.java
@@ -17,12 +17,17 @@ import com.amazonaws.ml.mms.util.messages.Predictions;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class ModelResponseDecoder extends ByteToMessageDecoder {
 
-    private static final int MAX_BUFFER_SIZE = 6553500;
+    private final int maxBufferSize;
+
+    public ModelResponseDecoder(int maxBufferSize) {
+        this.maxBufferSize = maxBufferSize;
+    }
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
@@ -37,27 +42,27 @@ public class ModelResponseDecoder extends ByteToMessageDecoder {
             ModelWorkerResponse resp = new ModelWorkerResponse();
             resp.setCode(in.readInt());
 
-            int len = CodecUtils.readLength(in, MAX_BUFFER_SIZE);
+            int len = CodecUtils.readLength(in, maxBufferSize);
             if (len == CodecUtils.BUFFER_UNDER_RUN) {
                 return;
             }
             resp.setMessage(CodecUtils.readString(in, len));
 
             List<Predictions> predictions = new ArrayList<>();
-            while ((len = CodecUtils.readLength(in, MAX_BUFFER_SIZE)) != CodecUtils.END) {
+            while ((len = CodecUtils.readLength(in, maxBufferSize)) != CodecUtils.END) {
                 if (len == CodecUtils.BUFFER_UNDER_RUN) {
                     return;
                 }
                 Predictions prediction = new Predictions();
                 prediction.setRequestId(CodecUtils.readString(in, len));
 
-                len = CodecUtils.readLength(in, MAX_BUFFER_SIZE);
+                len = CodecUtils.readLength(in, maxBufferSize);
                 if (len == CodecUtils.BUFFER_UNDER_RUN) {
                     return;
                 }
                 prediction.setContentType(CodecUtils.readString(in, len));
 
-                len = CodecUtils.readLength(in, MAX_BUFFER_SIZE);
+                len = CodecUtils.readLength(in, maxBufferSize);
                 if (len == CodecUtils.BUFFER_UNDER_RUN) {
                     return;
                 }

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/codec/ModelResponseDecoder.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/codec/ModelResponseDecoder.java
@@ -17,7 +17,6 @@ import com.amazonaws.ml.mms.util.messages.Predictions;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -208,7 +208,7 @@ public class WorkerThread implements Runnable {
         setState(WorkerState.WORKER_STARTED);
         final CountDownLatch latch = new CountDownLatch(1);
 
-        final int responseBufferSize = configManager.getBackendResponseBufferSize();
+        final int responseBufferSize = configManager.getMaxResponseSize();
         try {
             Connector connector = new Connector(port);
             Bootstrap b = new Bootstrap();

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -219,7 +219,7 @@ public class WorkerThread implements Runnable {
                                 public void initChannel(Channel ch) {
                                     ChannelPipeline p = ch.pipeline();
                                     p.addLast(ENCODER);
-                                    p.addLast(new ModelResponseDecoder());
+                                    p.addLast(new ModelResponseDecoder(configManager.getBackendResponseBufferSize()));
                                     p.addLast(new WorkerHandler());
                                 }
                             });

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -208,6 +208,7 @@ public class WorkerThread implements Runnable {
         setState(WorkerState.WORKER_STARTED);
         final CountDownLatch latch = new CountDownLatch(1);
 
+        final int responseBufferSize = configManager.getBackendResponseBufferSize();
         try {
             Connector connector = new Connector(port);
             Bootstrap b = new Bootstrap();
@@ -219,7 +220,7 @@ public class WorkerThread implements Runnable {
                                 public void initChannel(Channel ch) {
                                     ChannelPipeline p = ch.pipeline();
                                     p.addLast(ENCODER);
-                                    p.addLast(new ModelResponseDecoder(configManager.getBackendResponseBufferSize()));
+                                    p.addLast(new ModelResponseDecoder(responseBufferSize));
                                     p.addLast(new WorkerHandler());
                                 }
                             });


### PR DESCRIPTION
Resolves #762 

## Motivation
Enable models which return very large responses (eg. images / videos) to run within MMS.

## Description of changes
This PR adds a new optional configuration parameter, `backend_response_buffer_size`, which controls the max size allocated to a single worker response. The buffer size was previously hard-coded at 6553500 bytes, which now serves as the default value.

## Testing done
- Tested with an artificially large prediction response to verify the buffer size is used correctly.
- Ran CI locally.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
