### PR TITLE
Allow UUID to be a valid endpoint name

### DIFF
--- a/model-archiver/model_archiver/model_packaging_utils.py
+++ b/model-archiver/model_archiver/model_packaging_utils.py
@@ -302,10 +302,10 @@ class ModelExportUtils(object):
         :param model_name:
         :return:
         """
-        if not re.match(r'^[A-Za-z][A-Za-z0-9_\-.]*$', model_name):
+        if not re.match(r'^[A-Za-z0-9][A-Za-z0-9_\-.]*$', model_name):
             raise ModelArchiverError("Model name contains special characters.\n"
                                      "The allowed regular expression filter for model "
-                                     "name is: ^[A-Za-z][A-Za-z0-9_\\-.]*$")
+                                     "name is: ^[A-Za-z0-9][A-Za-z0-9_\\-.]*$")
 
     @staticmethod
     def validate_inputs(model_path, model_name, export_path):

--- a/model-archiver/model_archiver/tests/unit_tests/test_model_packaging_utils.py
+++ b/model-archiver/model_archiver/tests/unit_tests/test_model_packaging_utils.py
@@ -178,12 +178,13 @@ class TestExportModelUtils:
     class TestModelNameRegEx:
 
         def test_regex_pass(self):
-            model_names = ['my-awesome-model', 'Aa.model', 'a', 'aA.model', 'a1234.model', 'a-A-A.model']
+            model_names = ['my-awesome-model', 'Aa.model', 'a', 'aA.model', 'a1234.model', 'a-A-A.model', '123-abc']
             for m in model_names:
                 ModelExportUtils.check_model_name_regex_or_exit(m)
 
         def test_regex_fail(self):
-            model_names = ['abc%', '123.abc', '12-model-a.model', '##.model', '-.model']
+            model_names = ['abc%', '123$abc', 'abc!123', '@123', '(model', 'mdoel)',
+                           '12*model-a.model', '##.model', '-.model']
             for m in model_names:
                 with pytest.raises(ModelArchiverError):
                     ModelExportUtils.check_model_name_regex_or_exit(m)


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
Allow UUID to be a valid endpoint name
## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
