### PR TITLE
Adding the data_names params in mx.Module

### DIFF
--- a/examples/mxnet_vision/README.md
+++ b/examples/mxnet_vision/README.md
@@ -53,7 +53,7 @@ In this pre-trained model, input name is 'data' and shape is '(1,3,224,224)'. Wh
 ```python
 >>> import mxnet as mx
 >>> load_symbol, args, auxs = mx.model.load_checkpoint("squeezenet_v1.1", 0)
->>> mod = mx.mod.Module(load_symbol, label_names=None, context=mx.cpu())
+>>> mod = mx.mod.Module(load_symbol, label_names=None, data_names=['data'], context=mx.cpu())
 >>> mod.data_names
 ['data']
 >>> mod.bind(data_shapes=[('data', (1, 3, 224, 224))])


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
Adding data_names params in mx.mod.Module() vision examples.

## Error that I faced
>>> load_symbol, args, auxs = mx.model.load_checkpoint("mnist_cnn", 0)
>>> mod = mx.mod.Module(load_symbol, label_names=None, context=mx.cpu())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/mxnet/module/module.py", line 95, in __init__
    _check_input_names(symbol, data_names, "data", True)
  File "/usr/local/lib/python3.6/site-packages/mxnet/module/base_module.py", line 54, in _check_input_names
    raise ValueError(msg)
ValueError: You created Module with Module(..., data_names=['data']) but input with name 'data' is not found in symbol.list_arguments(). Did you mean one of:
     /conv2d_1_input1
     conv2d_1/kernel1
     conv2d_1/bias1
     conv2d_2/kernel1
     conv2d_2/bias1
     dense_1/kernel1
     dense_1/bias1
     dense_2/kernel1
     dense_2/bias1
 


## Description of changes:
Adding data_names params in mx.mod.Module() vision examples

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
