### PR TITLE
Added no-archive option for model-archiver

### DIFF
--- a/model-archiver/README.md
+++ b/model-archiver/README.md
@@ -69,13 +69,16 @@ optional arguments:
                         working directory.
   --archive-format {tgz,default}
                         The format in which the model artifacts are archived.
-                        tgz: This creates the model-archive in <model-
-                        name>.tar.gz format.If platform hosting MMS requires
-                        model-artifacts to be in ".tar.gz" use this option.
-                        default: This creates the model-archive in <model-
-                        name>.mar format. This is the default archiving format.
-                        Models archived in this format will be readily hostable
-                        on native MMS.
+                        "tgz": This creates the model-archive in <model-name>.tar.gz format.
+                        If platform hosting MMS requires model-artifacts to be in ".tar.gz"
+                        use this option.
+                        "no-archive": This option creates an non-archived version of model artifacts
+                        at "export-path/{model-name}" location. As a result of this choice,
+                        MANIFEST file will be created at "export-path/{model-name}" location
+                        without archiving these model files
+                        "default": This creates the model-archive in <model-name>.mar format.
+                        This is the default archiving format. Models archived in this format
+                        will be readily hostable on native MMS.
   -f, --force           When the -f or --force flag is specified, an existing
                         .mar file with same name as that provided in --model-
                         name in the path specified by --export-path will

--- a/model-archiver/model_archiver/arg_parser.py
+++ b/model-archiver/model_archiver/arg_parser.py
@@ -31,17 +31,16 @@ class ArgParser(object):
 
         """ Argument parser for mxnet-model-export
         """
-        # TODO Add more CLI args here later
-        runtime_types = ', '.join(s.value for s in RuntimeType)
 
-        parser_export = argparse.ArgumentParser(prog='model-archiver', description='Model Archiver Tool')
+        parser_export = argparse.ArgumentParser(prog='model-archiver', description='Model Archiver Tool',
+                                                formatter_class=argparse.RawTextHelpFormatter)
 
         parser_export.add_argument('--model-name',
                                    required=True,
                                    type=str,
                                    default=None,
-                                   help='Exported model name. Exported file will be named as '
-                                        'model-name.mar and saved in current working directory if no --export-path is '
+                                   help='Exported model name. Exported file will be named as\n'
+                                        'model-name.mar and saved in current working directory if no --export-path is\n'
                                         'specified, else it will be saved under the export path')
 
         parser_export.add_argument('--model-path',
@@ -62,36 +61,38 @@ class ArgParser(object):
                                    type=str,
                                    default=RuntimeType.PYTHON.value,
                                    choices=[s.value for s in RuntimeType],
-                                   help='The runtime specifies which language to run your inference code on. '
-                                        'The default runtime is {}. At the present moment we support the '
-                                        'following runtimes \n {}'.format(RuntimeType.PYTHON, runtime_types))
+                                   help='The runtime specifies which language to run your inference code on.\n'
+                                        'The default runtime is "python".')
 
         parser_export.add_argument('--export-path',
                                    required=False,
                                    type=str,
                                    default=os.getcwd(),
-                                   help='Path where the exported .mar file will be saved. This is an optional '
-                                        'parameter. If --export-path is not specified, the file will be saved in the '
+                                   help='Path where the exported .mar file will be saved. This is an optional\n'
+                                        'parameter. If --export-path is not specified, the file will be saved in the\n'
                                         'current working directory. ')
 
         parser_export.add_argument('--archive-format',
                                    required=False,
                                    type=str,
                                    default="default",
-                                   choices=["tgz", "default"],
+                                   choices=["tgz", "no-archive", "default"],
                                    help='The format in which the model artifacts are archived.\n'
-                                        'tgz: This creates the model-archive in <model-name>.tar.gz format.'
-                                        'If platform hosting MMS requires model-artifacts to be in \".tar.gz\"'
-                                        ' use this option.\n'
-                                        'default: This creates the model-archive in <model-name>.mar format.'
-                                        ' This is the default archiving format. Models archived in this format'
-                                        ' will be readily hostable on native MMS.\n')
+                                        'tgz: This creates the model-archive in <model-name>.tar.gz format.\n'
+                                        'If platform hosting MMS requires model-artifacts to be in ".tar.gz"\n'
+                                        'use this option.\n'
+                                        'no-archive: This option creates an non-archived version of model artifacts \n'
+                                        'at "export-path/{model-name}" location. This can be used when archiving \n'
+                                        'is not required.\n'
+                                        'default: This creates the model-archive in <model-name>.mar format.\n'
+                                        'This is the default archiving format. Models archived in this format\n'
+                                        'will be readily hostable on native MMS.\n')
 
         parser_export.add_argument('-f', '--force',
                                    required=False,
                                    action='store_true',
-                                   help='When the -f or --force flag is specified, an existing .mar file with same '
-                                        'name as that provided in --model-name in the path specified by --export-path '
+                                   help='When the -f or --force flag is specified, an existing .mar file with same\n'
+                                        'name as that provided in --model-name in the path specified by --export-path\n'
                                         'will overwritten')
 
         return parser_export

--- a/model-archiver/model_archiver/arg_parser.py
+++ b/model-archiver/model_archiver/arg_parser.py
@@ -78,13 +78,14 @@ class ArgParser(object):
                                    default="default",
                                    choices=["tgz", "no-archive", "default"],
                                    help='The format in which the model artifacts are archived.\n'
-                                        'tgz: This creates the model-archive in <model-name>.tar.gz format.\n'
+                                        '"tgz": This creates the model-archive in <model-name>.tar.gz format.\n'
                                         'If platform hosting MMS requires model-artifacts to be in ".tar.gz"\n'
                                         'use this option.\n'
-                                        'no-archive: This option creates an non-archived version of model artifacts \n'
-                                        'at "export-path/{model-name}" location. This can be used when archiving \n'
-                                        'is not required.\n'
-                                        'default: This creates the model-archive in <model-name>.mar format.\n'
+                                        '"no-archive": This option creates an non-archived version of model artifacts\n'
+                                        'at "export-path/{model-name}" location. As a result of this choice, \n'
+                                        'MANIFEST file will be created at "export-path/{model-name}" location\n'
+                                        'without archiving these model files\n'
+                                        '"default": This creates the model-archive in <model-name>.mar format.\n'
                                         'This is the default archiving format. Models archived in this format\n'
                                         'will be readily hostable on native MMS.\n')
 

--- a/model-archiver/model_archiver/tests/unit_tests/test_model_packaging.py
+++ b/model-archiver/model_archiver/tests/unit_tests/test_model_packaging.py
@@ -74,3 +74,14 @@ class TestModelPackaging:
         patches.export_utils.validate_inputs.assert_called()
         patches.export_utils.archive.assert_called()
         patches.export_utils.clean_temp_files.assert_called()
+
+    def test_export_model_method_tar(self, patches):
+        self.args.update(archive_format="no-archive")
+        patches.export_utils.check_mar_already_exists.return_value = '/Users/dummyUser/'
+        patches.export_utils.check_custom_model_types.return_value = '/Users/dummyUser', ['a.txt', 'b.txt']
+        patches.export_utils.zip.return_value = None
+
+        package_model(self.args, ModelExportUtils.generate_manifest_json(self.args))
+        patches.export_utils.validate_inputs.assert_called()
+        patches.export_utils.archive.assert_called()
+        patches.export_utils.clean_temp_files.assert_called()

--- a/model-archiver/model_archiver/tests/unit_tests/test_model_packaging_utils.py
+++ b/model-archiver/model_archiver/tests/unit_tests/test_model_packaging_utils.py
@@ -68,6 +68,13 @@ class TestExportModelUtils:
             patches.path_exists.assert_called_once_with("/Users/dummyUser/some-model.tar.gz")
             assert ret_val == "/Users/dummyUser"
 
+        def test_export_file_is_none_tar(self, patches):
+            patches.path_exists.return_value = False
+            ret_val = ModelExportUtils.check_mar_already_exists('some-model', None, False, archive_format='no-archive')
+
+            patches.path_exists.assert_called_once_with("/Users/dummyUser/some-model")
+            assert ret_val == "/Users/dummyUser"
+
 
     # noinspection PyClassHasNoInit
     class TestCustomModelTypes:


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
This generates just the MANIFEST when archiving is not required. This can be especially useful for model-serving platforms which do not want to archive the model-artifacts

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
