### PR TITLE
Optional preprocessing of onnx files

### DIFF
--- a/model-archiver/model_archiver/arg_parser.py
+++ b/model-archiver/model_archiver/arg_parser.py
@@ -96,4 +96,13 @@ class ArgParser(object):
                                         'name as that provided in --model-name in the path specified by --export-path\n'
                                         'will overwritten')
 
+        parser_export.add_argument('-c', '--convert',
+                                   required=False,
+                                   action='store_true',
+                                   help='When this option is used, model-archiver looks for special files and tries\n'
+                                        'preprocesses them. For example, if this option is chosen when running\n'
+                                        'model-archiver tool on a model with ".onnx" extension, the tool will try and\n'
+                                        'convert ".onnx" model into an MXNet model.')
+
+
         return parser_export

--- a/model-archiver/model_archiver/model_packaging.py
+++ b/model-archiver/model_archiver/model_packaging.py
@@ -35,8 +35,10 @@ def package_model(args, manifest):
                                                                      args.force, args.archive_format)
 
         # Step 2 : Check if any special handling is required for custom models like onnx models
-        t, files_to_exclude = ModelExportUtils.check_custom_model_types(model_path, model_name)
-        temp_files.extend(t)
+        files_to_exclude = []
+        if args.convert:
+            t, files_to_exclude = ModelExportUtils.check_custom_model_types(model_path, model_name)
+            temp_files.extend(t)
 
         # Step 3 : Zip 'em all up
         ModelExportUtils.archive(export_file_path, model_name, model_path, files_to_exclude, manifest,

--- a/model-archiver/model_archiver/tests/unit_tests/test_model_packaging.py
+++ b/model-archiver/model_archiver/tests/unit_tests/test_model_packaging.py
@@ -38,7 +38,7 @@ class TestModelPackaging:
 
     args = Namespace(author=author, email=email, engine=engine, model_name=model_name, handler=handler,
                      runtime=RuntimeType.PYTHON.value, model_path=model_path, export_path=export_path, force=False,
-                     archive_format="default")
+                     archive_format="default", convert=False)
 
     @pytest.fixture()
     def patches(self, mocker):


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
Conversion of ONNX to MXNet models needs to be optional. For example, sagemaker customers have actual need to package ONNX models as-is

 https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/mxnet_onnx_superresolution/mxnet_onnx.ipynb

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
