### PR TITLE
Added logic to be able to configure default handler through config file

### DIFF
--- a/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/ModelArchive.java
+++ b/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/ModelArchive.java
@@ -217,6 +217,11 @@ public class ModelArchive {
                 }
             }
 
+            if (manifest.getModel().getModelName() == null
+                    || manifest.getModel().getModelName().isEmpty()) {
+                manifest.getModel().setModelName(url);
+            }
+
             failed = false;
             return new ModelArchive(manifest, url, dir, extracted);
         } finally {

--- a/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/ModelArchive.java
+++ b/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/ModelArchive.java
@@ -217,11 +217,6 @@ public class ModelArchive {
                 }
             }
 
-            if (manifest.getModel().getModelName() == null
-                    || manifest.getModel().getModelName().isEmpty()) {
-                manifest.getModel().setModelName(url);
-            }
-
             failed = false;
             return new ModelArchive(manifest, url, dir, extracted);
         } finally {
@@ -328,6 +323,10 @@ public class ModelArchive {
             clean();
             throw e;
         }
+    }
+
+    public String getHandler() {
+        return manifest.getModel().getHandler();
     }
 
     public Manifest getManifest() {

--- a/frontend/modelarchive/src/test/resources/models/noop-no-manifest/service.py
+++ b/frontend/modelarchive/src/test/resources/models/noop-no-manifest/service.py
@@ -1,0 +1,120 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+NoopService defines a no operational model handler.
+"""
+import logging
+import time
+
+
+class NoopService(object):
+    """
+    Noop Model handler implementation.
+
+    Extend from BaseModelHandler is optional
+    """
+
+    def __init__(self):
+        self._context = None
+        self.initialized = False
+
+    def initialize(self, context):
+        """
+        Initialize model. This will be called during model loading time
+
+        :param context: model server context
+        :return:
+        """
+        self.initialized = True
+        self._context = context
+
+    @staticmethod
+    def preprocess(data):
+        """
+        Transform raw input into model input data.
+
+        :param data: list of objects, raw input from request
+        :return: list of model input data
+        """
+        return data
+
+    @staticmethod
+    def inference(model_input):
+        """
+        Internal inference methods
+
+        :param model_input: transformed model input data
+        :return: inference results
+        """
+        return model_input
+
+    @staticmethod
+    def postprocess(model_output):
+        return ["OK"] * len(model_output)
+
+    def handle(self, data, context):
+        """
+        Custom service entry point function.
+
+        :param context: model server context
+        :param data: list of objects, raw input from request
+        :return: list of outputs to be send back to client
+        """
+        # Add your initialization code here
+        properties = context.system_properties
+        server_name = properties.get("server_name")
+        server_version = properties.get("server_version")
+        model_dir = properties.get("model_dir")
+        gpu_id = properties.get("gpu_id")
+        batch_size = properties.get("batch_size")
+
+        logging.debug("server_name: {}".format(server_name))
+        logging.debug("server_version: {}".format(server_version))
+        logging.debug("model_dir: {}".format(model_dir))
+        logging.debug("gpu_id: {}".format(gpu_id))
+        logging.debug("batch_size: {}".format(batch_size))
+        request_processor = context.request_processor
+        try:
+            preprocess_start = time.time()
+            data = self.preprocess(data)
+            inference_start = time.time()
+            data = self.inference(data)
+            postprocess_start = time.time()
+            data = self.postprocess(data)
+            end_time = time.time()
+
+            context.set_response_content_type(context.request_ids[0], "text/plain")
+
+            content_type = request_processor.get_request_property("Content-Type")
+            logging.debug("content_type: {}".format(content_type))
+
+            metrics = context.metrics
+            metrics.add_time("PreprocessTime", round((inference_start - preprocess_start) * 1000, 2))
+            metrics.add_time("InferenceTime", round((postprocess_start - inference_start) * 1000, 2))
+            metrics.add_time("PostprocessTime", round((end_time - postprocess_start) * 1000, 2))
+            return data
+        except Exception as e:
+            logging.error(e, exc_info=True)
+            request_processor.report_status(500, "Unknown inference error.")
+            return ["Error {}".format(str(e))] * len(data)
+
+
+_service = NoopService()
+
+
+def handle(data, context):
+    if not _service.initialized:
+        _service.initialize(context)
+
+    if data is None:
+        return None
+
+    return _service.handle(data, context)

--- a/frontend/modelarchive/src/test/resources/models/noop-no-manifest/service.py
+++ b/frontend/modelarchive/src/test/resources/models/noop-no-manifest/service.py
@@ -69,41 +69,18 @@ class NoopService(object):
         :return: list of outputs to be send back to client
         """
         # Add your initialization code here
-        properties = context.system_properties
-        server_name = properties.get("server_name")
-        server_version = properties.get("server_version")
-        model_dir = properties.get("model_dir")
-        gpu_id = properties.get("gpu_id")
-        batch_size = properties.get("batch_size")
-
-        logging.debug("server_name: {}".format(server_name))
-        logging.debug("server_version: {}".format(server_version))
-        logging.debug("model_dir: {}".format(model_dir))
-        logging.debug("gpu_id: {}".format(gpu_id))
-        logging.debug("batch_size: {}".format(batch_size))
         request_processor = context.request_processor
         try:
-            preprocess_start = time.time()
             data = self.preprocess(data)
-            inference_start = time.time()
             data = self.inference(data)
-            postprocess_start = time.time()
             data = self.postprocess(data)
-            end_time = time.time()
 
-            context.set_response_content_type(context.request_ids[0], "text/plain")
+            context.set_response_content_type(0, "text/plain")
 
-            content_type = request_processor.get_request_property("Content-Type")
-            logging.debug("content_type: {}".format(content_type))
-
-            metrics = context.metrics
-            metrics.add_time("PreprocessTime", round((inference_start - preprocess_start) * 1000, 2))
-            metrics.add_time("InferenceTime", round((postprocess_start - inference_start) * 1000, 2))
-            metrics.add_time("PostprocessTime", round((end_time - postprocess_start) * 1000, 2))
             return data
         except Exception as e:
             logging.error(e, exc_info=True)
-            request_processor.report_status(500, "Unknown inference error.")
+            request_processor[0].report_status(500, "Unknown inference error.")
             return ["Error {}".format(str(e))] * len(data)
 
 

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ManagementRequestHandler.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ManagementRequestHandler.java
@@ -186,6 +186,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
         ModelManager modelManager = ModelManager.getInstance();
         final ModelArchive archive;
         try {
+
             archive =
                     modelManager.registerModel(
                             modelUrl,
@@ -194,7 +195,8 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                             handler,
                             batchSize,
                             maxBatchDelay,
-                            responseTimeout);
+                            responseTimeout,
+                            null);
         } catch (IOException e) {
             throw new InternalServerException("Failed to save model: " + modelUrl, e);
         }

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -239,7 +239,7 @@ public final class ConfigManager {
     }
 
     public String getMmsDefaultServiceHandler() {
-        return getProperty(MMS_DEFAULT_SERVICE_HANDLER, "");
+        return getProperty(MMS_DEFAULT_SERVICE_HANDLER, null);
     }
 
     public int getDefaultWorkers() {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -79,6 +79,7 @@ public final class ConfigManager {
     private static final String MMS_PRIVATE_KEY_FILE = "private_key_file";
     private static final String MMS_MAX_REQUEST_SIZE = "max_request_size";
     private static final String MMS_MAX_RESPONSE_SIZE = "max_response_size";
+    private static final String MMS_DEFAULT_SERVICE_HANDLER = "default_service_handler";
     private static final String MODEL_SERVER_HOME = "model_server_home";
     private static final String MMS_MODEL_STORE = "model_store";
 
@@ -235,6 +236,10 @@ public final class ConfigManager {
 
     public int getNumberOfGpu() {
         return getIntProperty(MMS_NUMBER_OF_GPU, 0);
+    }
+
+    public String getMmsDefaultServiceHandler() {
+        return getProperty(MMS_DEFAULT_SERVICE_HANDLER, "");
     }
 
     public int getDefaultWorkers() {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
@@ -83,7 +83,7 @@ public final class ModelManager {
 
         ModelArchive archive = ModelArchive.downloadModel(configManager.getModelStore(), url);
         if (modelName == null || modelName.isEmpty()) {
-            modelName = archive.getModelName();
+            modelName = archive.getModelName().isEmpty() ? url : archive.getModelName();
         } else {
             archive.getManifest().getModel().setModelName(modelName);
         }
@@ -92,6 +92,13 @@ public final class ModelManager {
         }
         if (handler != null) {
             archive.getManifest().getModel().setHandler(handler);
+        }
+
+        if (archive.getManifest().getModel().getHandler() == null
+                || archive.getManifest().getModel().getHandler().isEmpty()) {
+            archive.getManifest()
+                    .getModel()
+                    .setHandler(configManager.getMmsDefaultServiceHandler());
         }
 
         archive.validate();

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
@@ -66,9 +66,17 @@ public final class ModelManager {
         return modelManager;
     }
 
-    public ModelArchive registerModel(String url) throws ModelException, IOException {
+    public ModelArchive registerModel(String url, String defaultModelName)
+            throws ModelException, IOException {
         return registerModel(
-                url, null, null, null, 1, 100, configManager.getDefaultResponseTimeout());
+                url,
+                null,
+                null,
+                null,
+                1,
+                100,
+                configManager.getDefaultResponseTimeout(),
+                defaultModelName);
     }
 
     public ModelArchive registerModel(
@@ -78,12 +86,16 @@ public final class ModelManager {
             String handler,
             int batchSize,
             int maxBatchDelay,
-            int responseTimeout)
+            int responseTimeout,
+            String defaultModelName)
             throws ModelException, IOException {
 
         ModelArchive archive = ModelArchive.downloadModel(configManager.getModelStore(), url);
         if (modelName == null || modelName.isEmpty()) {
-            modelName = archive.getModelName().isEmpty() ? url : archive.getModelName();
+            if (archive.getModelName() == null || archive.getModelName().isEmpty()) {
+                archive.getManifest().getModel().setModelName(defaultModelName);
+            }
+            modelName = archive.getModelName();
         } else {
             archive.getManifest().getModel().setModelName(modelName);
         }
@@ -92,10 +104,7 @@ public final class ModelManager {
         }
         if (handler != null) {
             archive.getManifest().getModel().setHandler(handler);
-        }
-
-        if (archive.getManifest().getModel().getHandler() == null
-                || archive.getManifest().getModel().getHandler().isEmpty()) {
+        } else if (archive.getHandler() == null || archive.getHandler().isEmpty()) {
             archive.getManifest()
                     .getModel()
                     .setHandler(configManager.getMmsDefaultServiceHandler());

--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -551,33 +551,33 @@ public class ModelServerTest {
 
     private void testPredictionsModifyResponseHeader(
             Channel inferChannel, Channel managementChannel)
-        throws NoSuchFieldException, IllegalAccessException, InterruptedException {
-            setConfiguration("decode_input_request", "false");
-            loadTests(managementChannel, "respheader-test", "respheader");
-            result = null;
-            latch = new CountDownLatch(1);
-            DefaultFullHttpRequest req =
-                    new DefaultFullHttpRequest(
-                            HttpVersion.HTTP_1_1, HttpMethod.POST, "/predictions/respheader");
+            throws NoSuchFieldException, IllegalAccessException, InterruptedException {
+        setConfiguration("decode_input_request", "false");
+        loadTests(managementChannel, "respheader-test", "respheader");
+        result = null;
+        latch = new CountDownLatch(1);
+        DefaultFullHttpRequest req =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1, HttpMethod.POST, "/predictions/respheader");
 
-            req.content().writeCharSequence("{\"data\": \"test\"}", CharsetUtil.UTF_8);
-            HttpUtil.setContentLength(req, req.content().readableBytes());
-            req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
-            inferChannel.writeAndFlush(req);
+        req.content().writeCharSequence("{\"data\": \"test\"}", CharsetUtil.UTF_8);
+        HttpUtil.setContentLength(req, req.content().readableBytes());
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+        inferChannel.writeAndFlush(req);
 
-            latch.await();
+        latch.await();
 
-            Assert.assertEquals(httpStatus, HttpResponseStatus.OK);
-            Assert.assertEquals(headers.get("dummy"), "1");
-            Assert.assertEquals(headers.get("content-type"), "text/plain");
-            Assert.assertTrue(result.contains("bytearray"));
-            unloadTests(managementChannel, "respheader");
-        }
+        Assert.assertEquals(httpStatus, HttpResponseStatus.OK);
+        Assert.assertEquals(headers.get("dummy"), "1");
+        Assert.assertEquals(headers.get("content-type"), "text/plain");
+        Assert.assertTrue(result.contains("bytearray"));
+        unloadTests(managementChannel, "respheader");
+    }
 
     private void testPredictionsNoManifest(Channel inferChannel, Channel mgmtChannel)
-        throws InterruptedException, NoSuchFieldException, IllegalAccessException {
-            setConfiguration("default_service_handler", "service:handle");
-            loadTests(mgmtChannel, "noop-no-manifest", "nomanifest");
+            throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        setConfiguration("default_service_handler", "service:handle");
+        loadTests(mgmtChannel, "noop-no-manifest", "nomanifest");
 
         result = null;
         latch = new CountDownLatch(1);

--- a/frontend/server/src/test/resources/config.properties
+++ b/frontend/server/src/test/resources/config.properties
@@ -26,3 +26,4 @@ max_request_size=10485760
 # enable_env_vars_config=false
 # decode_input_request=true
 enable_envvars_config=true
+# default_service_handler=/path/to/service.py:handle

--- a/mms/tests/unit_tests/model_service/dummy_model/MANIFEST.json
+++ b/mms/tests/unit_tests/model_service/dummy_model/MANIFEST.json
@@ -1,0 +1,14 @@
+{
+  "Engine": {
+    "MXNet": 0.12
+  },
+  "Model-Archive-Description": "dummy",
+  "License": "Apache 2.0",
+  "Model-Archive-Version": 0.1,
+  "Model-Server": 0.1,
+  "Model": {
+    "Description": "dummy model",
+    "Service": "dummy_model_service.py",
+    "Model-Name": "dummy",
+  }
+}

--- a/mms/tests/unit_tests/model_service/dummy_model/dummy_model_service.py
+++ b/mms/tests/unit_tests/model_service/dummy_model/dummy_model_service.py
@@ -10,9 +10,9 @@
 
 from mms.model_service.model_service import SingleNodeService
 
-'''
+"""
 This file is a dummy file for the purpose of unit-testing test_service_manager.py
-'''
+"""
 
 
 class DummyNodeService(SingleNodeService):

--- a/mms/tests/unit_tests/test_model_loader.py
+++ b/mms/tests/unit_tests/test_model_loader.py
@@ -84,10 +84,11 @@ class TestLoadModels:
         patches.mock_open.side_effect = [mock.mock_open(read_data=self.mock_manifest).return_value]
         patches.open_signature.side_effect = [mock.mock_open(read_data='{}').return_value]
         patches.is_file.return_value = True
-        patches.os_path.return_value = False
+        patches.os_path.side_effect = [False, True]
         sys.path.append(self.model_dir)
         handler = 'dummy_model_service'
         model_loader = ModelLoaderFactory.get_model_loader(self.model_dir)
+        assert isinstance(model_loader, LegacyModelLoader)
         service = model_loader.load(self.model_name, self.model_dir, handler, 0, 1)
 
         assert inspect.ismethod(service._entry_point)


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
Add logic to handle default service handler if MANIFEST is not found or if no handler is configured in the MANIFEST.

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
