### PR TITLE
Added special handling for returning various errors during model initialization

### DIFF
--- a/frontend/modelarchive/src/test/resources/models/loading-memory-error/MAR-INF/MANIFEST.json
+++ b/frontend/modelarchive/src/test/resources/models/loading-memory-error/MAR-INF/MANIFEST.json
@@ -1,0 +1,18 @@
+{
+  "specificationVersion": "1.0",
+  "implementationVersion": "1.0",
+  "description": "noop v1.0",
+  "modelServerVersion": "1.0",
+  "license": "Apache 2.0",
+  "runtime": "python",
+  "model": {
+    "modelName": "mem-err",
+    "description": "Tests for memory error",
+    "modelVersion": "1.0",
+    "handler": "service:handle"
+  },
+  "publisher": {
+    "author": "MXNet SDK team",
+    "email": "noreply@amazon.com"
+  }
+}

--- a/frontend/modelarchive/src/test/resources/models/loading-memory-error/service.py
+++ b/frontend/modelarchive/src/test/resources/models/loading-memory-error/service.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def handle(ctx, data):
+    some_str = "*" * 200000000000000
+    return [some_str]

--- a/frontend/modelarchive/src/test/resources/models/prediction-memory-error/MAR-INF/MANIFEST.json
+++ b/frontend/modelarchive/src/test/resources/models/prediction-memory-error/MAR-INF/MANIFEST.json
@@ -1,0 +1,18 @@
+{
+  "specificationVersion": "1.0",
+  "implementationVersion": "1.0",
+  "description": "noop v1.0",
+  "modelServerVersion": "1.0",
+  "license": "Apache 2.0",
+  "runtime": "python",
+  "model": {
+    "modelName": "pred-mem-err",
+    "description": "Tests for memory error",
+    "modelVersion": "1.0",
+    "handler": "service:handle"
+  },
+  "publisher": {
+    "author": "MXNet SDK team",
+    "email": "noreply@amazon.com"
+  }
+}

--- a/frontend/modelarchive/src/test/resources/models/prediction-memory-error/service.py
+++ b/frontend/modelarchive/src/test/resources/models/prediction-memory-error/service.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def handle(data, ctx):
+    some_str = "hello"
+    # Data is not none in prediction request
+    if data is not None:
+        some_str = "*" * 200000000000000
+    return [some_str]

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ManagementRequestHandler.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ManagementRequestHandler.java
@@ -270,7 +270,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
             final Function<Void, Void> onError) {
 
         ModelManager modelManager = ModelManager.getInstance();
-        CompletableFuture<Boolean> future =
+        CompletableFuture<HttpResponseStatus> future =
                 modelManager.updateModel(modelName, minWorkers, maxWorkers);
         if (!synchronous) {
             NettyUtils.sendJsonResponse(
@@ -282,12 +282,10 @@ public class ManagementRequestHandler extends HttpRequestHandler {
         future.thenApply(
                         v -> {
                             boolean status = modelManager.scaleRequestStatus(modelName);
-                            if (v) {
+                            if (HttpResponseStatus.OK.equals(v)) {
                                 if (status) {
                                     NettyUtils.sendJsonResponse(
-                                            ctx,
-                                            new StatusResponse("Workers scaled"),
-                                            HttpResponseStatus.OK);
+                                            ctx, new StatusResponse("Workers scaled"), v);
                                 } else {
                                     NettyUtils.sendJsonResponse(
                                             ctx,
@@ -297,7 +295,7 @@ public class ManagementRequestHandler extends HttpRequestHandler {
                             } else {
                                 NettyUtils.sendError(
                                         ctx,
-                                        HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                        v,
                                         new InternalServerException("Failed to start workers"));
                                 if (onError != null) {
                                     onError.apply(null);

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/BatchAggregator.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/BatchAggregator.java
@@ -103,7 +103,7 @@ public class BatchAggregator {
         }
     }
 
-    public void sendError(BaseModelRequest message, String error) {
+    public void sendError(BaseModelRequest message, String error, HttpResponseStatus status) {
         if (message instanceof ModelLoadModelRequest) {
             logger.warn("Load model failed: {}, error: {}", message.getModelName(), error);
             return;
@@ -117,7 +117,7 @@ public class BatchAggregator {
                 if (job == null) {
                     logger.error("Unexpected job: " + requestId);
                 } else {
-                    job.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR, error);
+                    job.sendError(status, error);
                 }
             }
             if (!jobs.isEmpty()) {
@@ -131,7 +131,7 @@ public class BatchAggregator {
                 Job job = jobs.remove(jobsId);
 
                 if (job.isControlCmd()) {
-                    job.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR, error);
+                    job.sendError(status, error);
                 } else {
                     // Data message can be handled by other workers.
                     // If batch has gone past its batch max delay timer?

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
@@ -142,7 +142,7 @@ public final class ModelManager {
         return true;
     }
 
-    public CompletableFuture<Boolean> updateModel(
+    public CompletableFuture<HttpResponseStatus> updateModel(
             String modelName, int minWorkers, int maxWorkers) {
         Model model = models.get(modelName);
         if (model == null) {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerStateListener.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerStateListener.java
@@ -12,28 +12,29 @@
  */
 package com.amazonaws.ml.mms.wlm;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class WorkerStateListener {
 
-    private CompletableFuture<Boolean> future;
+    private CompletableFuture<HttpResponseStatus> future;
     private AtomicInteger count;
 
-    public WorkerStateListener(CompletableFuture<Boolean> future, int count) {
+    public WorkerStateListener(CompletableFuture<HttpResponseStatus> future, int count) {
         this.future = future;
         this.count = new AtomicInteger(count);
     }
 
-    public void notifyChangeState(String modelName, WorkerState state) {
+    public void notifyChangeState(String modelName, WorkerState state, HttpResponseStatus status) {
         // Update success and fail counts
         if (state == WorkerState.WORKER_MODEL_LOADED) {
             if (count.decrementAndGet() == 0) {
-                future.complete(Boolean.TRUE);
+                future.complete(status);
             }
         }
         if (state == WorkerState.WORKER_ERROR || state == WorkerState.WORKER_STOPPED) {
-            future.complete(Boolean.FALSE);
+            future.complete(status);
         }
     }
 }

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -158,9 +158,6 @@ public class WorkerThread implements Runnable {
                                     WorkerState.WORKER_ERROR,
                                     HttpResponseStatus.valueOf(reply.getCode()));
                             status = HttpResponseStatus.valueOf(reply.getCode());
-                            throw new WorkerInitializationException(
-                                    "Backend worker did not initialize. Msg - "
-                                            + reply.getMessage());
                         }
                         break;
                     case UNLOAD:

--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -175,6 +175,8 @@ public class ModelServerTest {
         testPredictionsDoNotDecodeRequest(channel, managementChannel);
         testPredictionsModifyResponseHeader(channel, managementChannel);
         testPredictionsNoManifest(channel, managementChannel);
+        testLoadingMemoryError();
+        testPredictionMemoryError();
         testMetricManager();
         testErrorBatch();
 
@@ -1000,6 +1002,67 @@ public class ModelServerTest {
         Assert.assertEquals(httpStatus, HttpResponseStatus.SERVICE_UNAVAILABLE);
         Assert.assertEquals(resp.getCode(), HttpResponseStatus.SERVICE_UNAVAILABLE.code());
         Assert.assertEquals(resp.getMessage(), "Invalid model predict output");
+    }
+
+    private void testLoadingMemoryError() throws InterruptedException {
+        Channel channel = connect(true);
+        Assert.assertNotNull(channel);
+        result = null;
+        latch = new CountDownLatch(1);
+        HttpRequest req =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.POST,
+                        "/models?url=loading-memory-error&model_name=memory_error&runtime=python&initial_workers=1&synchronous=true");
+        channel.writeAndFlush(req);
+        latch.await();
+
+        Assert.assertEquals(httpStatus, HttpResponseStatus.INSUFFICIENT_STORAGE);
+        channel.close();
+    }
+
+    private void testPredictionMemoryError() throws InterruptedException {
+        // Load the model
+        Channel channel = connect(true);
+        Assert.assertNotNull(channel);
+        result = null;
+        latch = new CountDownLatch(1);
+        DefaultFullHttpRequest req =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.POST,
+                        "/models?url=prediction-memory-error&model_name=pred-err&runtime=python&initial_workers=1&synchronous=true");
+        channel.writeAndFlush(req);
+        latch.await();
+        Assert.assertEquals(httpStatus, HttpResponseStatus.OK);
+        channel.close();
+
+        // Test for prediction
+        channel = connect(false);
+        Assert.assertNotNull(channel);
+        result = null;
+        latch = new CountDownLatch(1);
+        req =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1, HttpMethod.POST, "/predictions/pred-err");
+        req.content().writeCharSequence("data=invalid_output", CharsetUtil.UTF_8);
+
+        channel.writeAndFlush(req);
+        latch.await();
+
+        Assert.assertEquals(httpStatus, HttpResponseStatus.INSUFFICIENT_STORAGE);
+        channel.close();
+
+        // Unload the model
+        channel = connect(true);
+        latch = new CountDownLatch(1);
+        Assert.assertNotNull(channel);
+        req =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1, HttpMethod.DELETE, "/models/pred-err");
+        channel.writeAndFlush(req);
+        latch.await();
+        Assert.assertEquals(httpStatus, HttpResponseStatus.OK);
     }
 
     private void testErrorBatch() throws InterruptedException {

--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -120,6 +120,8 @@ class MXNetModelServiceWorker(object):
                 resp = bytearray()
                 resp += create_load_model_response(code, result)
                 cl_socket.send(resp)
+                if code != 200:
+                    raise RuntimeError("{} - {}".format(code, result))
             else:
                 raise ValueError("Received unknown command: {}".format(cmd))
 

--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -81,23 +81,26 @@ class MXNetModelServiceWorker(object):
         :param load_model_request:
         :return:
         """
-        model_dir = load_model_request["modelPath"].decode("utf-8")
-        model_name = load_model_request["modelName"].decode("utf-8")
-        handler = load_model_request["handler"].decode("utf-8")
-        batch_size = None
-        if "batchSize" in load_model_request:
-            batch_size = int(load_model_request["batchSize"])
+        try:
+            model_dir = load_model_request["modelPath"].decode("utf-8")
+            model_name = load_model_request["modelName"].decode("utf-8")
+            handler = load_model_request["handler"].decode("utf-8")
+            batch_size = None
+            if "batchSize" in load_model_request:
+                batch_size = int(load_model_request["batchSize"])
 
-        gpu = None
-        if "gpu" in load_model_request:
-            gpu = int(load_model_request["gpu"])
+            gpu = None
+            if "gpu" in load_model_request:
+                gpu = int(load_model_request["gpu"])
 
-        model_loader = ModelLoaderFactory.get_model_loader(model_dir)
-        service = model_loader.load(model_name, model_dir, handler, gpu, batch_size)
+            model_loader = ModelLoaderFactory.get_model_loader(model_dir)
+            service = model_loader.load(model_name, model_dir, handler, gpu, batch_size)
 
-        logging.debug("Model %s loaded.", model_name)
+            logging.debug("Model %s loaded.", model_name)
 
-        return service, "loaded model {}".format(model_name), 200
+            return service, "loaded model {}".format(model_name), 200
+        except MemoryError:
+            return None, "System out of memory", 507
 
     def handle_connection(self, cl_socket):
         """

--- a/mms/service.py
+++ b/mms/service.py
@@ -106,6 +106,9 @@ class Service(object):
         # noinspection PyBroadException
         try:
             ret = self._entry_point(input_batch, self.context)
+        except MemoryError:
+            logger.error("System out of memory", exc_info=True)
+            return create_predict_response(None, req_id_map, "Out of resources", 507)
         except Exception:  # pylint: disable=broad-except
             logger.warning("Invoking custom service failed.", exc_info=True)
             return create_predict_response(None, req_id_map, "Prediction failed", 503)


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
MMS orchestrators need to be notified of OOM errors which occur during Model Initialization or prediction times. This can be used by the orchestrators to re-distribute the workers on different hosts.

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
