### PR TITLE
Initialize HTTP Status for tests to make sure the actual http status …

### DIFF
--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -1097,6 +1097,7 @@ public class ModelServerTest {
 
         // Unload the model
         channel = connect(true);
+        httpStatus = null;
         latch = new CountDownLatch(1);
         Assert.assertNotNull(channel);
         req =


### PR DESCRIPTION
…is captured

Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
Initialized the HTTP status to see the actual error that is seen in the CI. Sometime CI is being flaky for this test. If this persists, we can safely disable the check on line 1108. 

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
