### PR TITLE
Multiple fixes

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandler.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandler.java
@@ -64,6 +64,9 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
         } catch (ServiceUnavailableException e) {
             logger.trace("", e);
             NettyUtils.sendError(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, e);
+        } catch (OutOfMemoryError e) {
+            logger.trace("", e);
+            NettyUtils.sendError(ctx, HttpResponseStatus.INSUFFICIENT_STORAGE, e);
         } catch (Throwable t) {
             logger.error("", t);
             NettyUtils.sendError(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, t);
@@ -74,6 +77,9 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         logger.error("", cause);
+        if (cause instanceof OutOfMemoryError) {
+            NettyUtils.sendError(ctx, HttpResponseStatus.INSUFFICIENT_STORAGE, cause);
+        }
         ctx.close();
     }
 }

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandlerChain.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandlerChain.java
@@ -103,6 +103,9 @@ public abstract class HttpRequestHandlerChain {
                     } catch (ModelServerEndpointException me) {
                         NettyUtils.sendError(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, me);
                         logger.error("Error thrown by the model endpoint plugin.", me);
+                    } catch (OutOfMemoryError oom) {
+                        NettyUtils.sendError(
+                                ctx, HttpResponseStatus.INSUFFICIENT_STORAGE, oom, "Out of memory");
                     } catch (IOException ioe) {
                         NettyUtils.sendError(
                                 ctx,

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
@@ -12,6 +12,7 @@
  */
 package com.amazonaws.ml.mms.http.messages;
 
+import com.amazonaws.ml.mms.util.ConfigManager;
 import com.amazonaws.ml.mms.util.NettyUtils;
 import com.google.gson.annotations.SerializedName;
 import io.netty.handler.codec.http.QueryStringDecoder;
@@ -51,7 +52,11 @@ public class RegisterModelRequest {
         handler = NettyUtils.getParameter(decoder, "handler", null);
         batchSize = NettyUtils.getIntParameter(decoder, "batch_size", 1);
         maxBatchDelay = NettyUtils.getIntParameter(decoder, "max_batch_delay", 100);
-        initialWorkers = NettyUtils.getIntParameter(decoder, "initial_workers", 0);
+        initialWorkers =
+                NettyUtils.getIntParameter(
+                        decoder,
+                        "initial_workers",
+                        ConfigManager.getInstance().getConfiguredDefaultWorkersPerModel());
         synchronous = Boolean.parseBoolean(NettyUtils.getParameter(decoder, "synchronous", "true"));
         responseTimeout = NettyUtils.getIntParameter(decoder, "response_timeout", -1);
         modelUrl = NettyUtils.getParameter(decoder, "url", null);

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
@@ -52,7 +52,7 @@ public class RegisterModelRequest {
         batchSize = NettyUtils.getIntParameter(decoder, "batch_size", 1);
         maxBatchDelay = NettyUtils.getIntParameter(decoder, "max_batch_delay", 100);
         initialWorkers = NettyUtils.getIntParameter(decoder, "initial_workers", 0);
-        synchronous = Boolean.parseBoolean(NettyUtils.getParameter(decoder, "synchronous", null));
+        synchronous = Boolean.parseBoolean(NettyUtils.getParameter(decoder, "synchronous", "true"));
         responseTimeout = NettyUtils.getIntParameter(decoder, "response_timeout", -1);
         modelUrl = NettyUtils.getParameter(decoder, "url", null);
     }

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -246,11 +246,15 @@ public final class ConfigManager {
         return new Properties(prop);
     }
 
+    public int getConfiguredDefaultWorkersPerModel() {
+        return getIntProperty(MMS_DEFAULT_WORKERS_PER_MODEL, 0);
+    }
+
     public int getDefaultWorkers() {
         if (isDebug()) {
             return 1;
         }
-        int workers = getIntProperty(MMS_DEFAULT_WORKERS_PER_MODEL, 0);
+        int workers = getConfiguredDefaultWorkersPerModel();
 
         if ((workers == 0) && (prop.getProperty("NUM_WORKERS", null) != null)) {
             workers = getIntProperty("NUM_WORKERS", 0);

--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -262,7 +262,7 @@ public class ModelServerTest {
                 new DefaultFullHttpRequest(
                         HttpVersion.HTTP_1_1,
                         HttpMethod.POST,
-                        "/models?url=noop-v0.1&model_name=noop_v0.1&runtime=python");
+                        "/models?url=noop-v0.1&model_name=noop_v0.1&runtime=python&synchronous=false");
         channel.writeAndFlush(req);
         latch.await();
 
@@ -888,7 +888,7 @@ public class ModelServerTest {
                 new DefaultFullHttpRequest(
                         HttpVersion.HTTP_1_1,
                         HttpMethod.POST,
-                        "/models?url=http%3A%2F%2Flocalhost%3A18888%2Ffake.mar");
+                        "/models?url=http%3A%2F%2Flocalhost%3A18888%2Ffake.mar&synchronous=false");
         channel.writeAndFlush(req).sync();
         channel.closeFuture().sync();
 
@@ -908,7 +908,7 @@ public class ModelServerTest {
                 new DefaultFullHttpRequest(
                         HttpVersion.HTTP_1_1,
                         HttpMethod.POST,
-                        "/models?url=https%3A%2F%2Flocalhost%3A8443%2Ffake.mar");
+                        "/models?url=https%3A%2F%2Flocalhost%3A8443%2Ffake.mar&synchronous=false");
         channel.writeAndFlush(req).sync();
         channel.closeFuture().sync();
 
@@ -926,7 +926,9 @@ public class ModelServerTest {
 
         HttpRequest req =
                 new DefaultFullHttpRequest(
-                        HttpVersion.HTTP_1_1, HttpMethod.POST, "/models?url=..%2Ffake.mar");
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.POST,
+                        "/models?url=..%2Ffake.mar&synchronous=false");
         channel.writeAndFlush(req).sync();
         channel.closeFuture().sync();
 
@@ -977,7 +979,7 @@ public class ModelServerTest {
                 new DefaultFullHttpRequest(
                         HttpVersion.HTTP_1_1,
                         HttpMethod.POST,
-                        "/models?url=init-error&model_name=init-error");
+                        "/models?url=init-error&model_name=init-error&synchronous=false");
         channel.writeAndFlush(req);
         latch.await();
 


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
1. This change makes the model registration a synchronous call by default.
2. This change makes model loading experience consistent. Currently when customers start MMS without any models, MMS looks up "default_workers_per_model" configuration to determine the number of workers. But, during registration this doesn't happen. This change keeps these two behaviors consistent.

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
