### PR TITLE
Send a conflict response instead of bad request when model is already registered

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ConflictStatusException.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ConflictStatusException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.ml.mms.http;
+
+public class ConflictStatusException extends IllegalArgumentException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs an {@code ConflictStatusException} with the specified detail message.
+     *
+     * @param message The detail message (which is saved for later retrieval by the {@link
+     *     #getMessage()} method)
+     */
+    public ConflictStatusException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs an {@code ConflictStatusException} with the specified detail message and cause.
+     *
+     * <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically
+     * incorporated into this exception's detail message.
+     *
+     * @param cause The cause (which is saved for later retrieval by the {@link #getCause()}
+     *     method). (A null value is permitted, and indicates that the cause is nonexistent or
+     *     unknown.)
+     */
+    public ConflictStatusException(Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+}

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandler.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandler.java
@@ -58,6 +58,9 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
         } catch (BadRequestException | ModelException e) {
             logger.trace("", e);
             NettyUtils.sendError(ctx, HttpResponseStatus.BAD_REQUEST, e);
+        } catch (ConflictStatusException e) {
+            logger.trace("", e);
+            NettyUtils.sendError(ctx, HttpResponseStatus.CONFLICT, e);
         } catch (MethodNotAllowedException e) {
             logger.trace("", e);
             NettyUtils.sendError(ctx, HttpResponseStatus.METHOD_NOT_ALLOWED, e);

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/openapi/OpenApiUtils.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/openapi/OpenApiUtils.java
@@ -353,6 +353,7 @@ public final class OpenApiUtils {
         operation.addResponse(new Response("210", "Partial Success", status));
         operation.addResponse(new Response("400", "Bad request", error));
         operation.addResponse(new Response("404", "Model not found", error));
+        operation.addResponse(new Response("409", "Model already registered", error));
         operation.addResponse(new Response("500", "Internal Server Error", error));
 
         return operation;

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
@@ -16,7 +16,7 @@ import com.amazonaws.ml.mms.archive.Manifest;
 import com.amazonaws.ml.mms.archive.ModelArchive;
 import com.amazonaws.ml.mms.archive.ModelException;
 import com.amazonaws.ml.mms.archive.ModelNotFoundException;
-import com.amazonaws.ml.mms.http.BadRequestException;
+import com.amazonaws.ml.mms.http.ConflictStatusException;
 import com.amazonaws.ml.mms.http.StatusResponse;
 import com.amazonaws.ml.mms.util.ConfigManager;
 import com.amazonaws.ml.mms.util.NettyUtils;
@@ -119,7 +119,7 @@ public final class ModelManager {
         Model existingModel = models.putIfAbsent(modelName, model);
         if (existingModel != null) {
             // model already exists
-            throw new BadRequestException("Model " + modelName + " is already registered.");
+            throw new ConflictStatusException("Model " + modelName + " is already registered.");
         }
         logger.info("Model {} loaded.", model.getModelName());
 

--- a/frontend/server/src/test/resources/management_open_api.json
+++ b/frontend/server/src/test/resources/management_open_api.json
@@ -387,6 +387,35 @@
               }
             }
           },
+          "409": {
+            "description": "Model already registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "type",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "description": "Error code."
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Error type."
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message."
+                    }
+                  }
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal Server Error",
             "content": {


### PR DESCRIPTION
## Issue #, if available:
None

## Description of changes:
Change response when attempting to register a model that has already been registered.

## Testing done:
Tested locally. Note CI tests not running right now (run_ci_tests.sh doesn't seem to run anything).

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
