### PR TITLE
Force synch response for unregistermodel

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -149,6 +149,7 @@ management_address=http://0.0.0.0:8081
 # number_of_netty_threads=0
 # netty_client_threads=0
 # default_response_timeout=120
+# unregister_model_timeout=120
 # default_workers_per_model=0
 # job_queue_size=100
 # async_logging=false

--- a/docker/advanced-dockerfiles/config.properties
+++ b/docker/advanced-dockerfiles/config.properties
@@ -7,6 +7,7 @@ management_address=http://0.0.0.0:8081
 # number_of_netty_threads=0
 # netty_client_threads=0
 # default_response_timeout=120
+# unregister_model_timeout=120
 # default_workers_per_model=0
 # job_queue_size=100
 # async_logging=false

--- a/docker/config.properties
+++ b/docker/config.properties
@@ -7,6 +7,7 @@ management_address=http://0.0.0.0:8081
 # number_of_netty_threads=0
 # netty_client_threads=0
 # default_response_timeout=120
+# unregister_model_timeout=120
 # default_workers_per_model=0
 # job_queue_size=100
 # async_logging=false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,7 @@ Most of those properties are designed for performance tuning. Adjusting those nu
 * job_queue_size: number inference jobs that frontend will queue before backend can serve, default 100.
 * async_logging: enable asynchronous logging for higher throughput, log output may be delayed if this is enabled, default: false.
 * default_response_timeout: Timeout, in seconds, used for model's backend workers before they are deemed unresponsive and rebooted. default: 120 seconds.
+* unregister_model_timeout: Timeout, in seconds, used when handling an unregister model request when cleaning a process before it is deemed unresponsive and an error response is sent. default: 120 seconds.
 * decode_input_request: Configuration to let backend workers to decode requests, when the content type is known. 
 If this is set to "true", backend workers do "Bytearray to JSON object" conversion when the content type is "application/json" and 
 the backend workers convert "Bytearray to utf-8 string" when the Content-Type of the request is set to "text*". default: true  

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandler.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/HttpRequestHandler.java
@@ -61,6 +61,9 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
         } catch (ConflictStatusException e) {
             logger.trace("", e);
             NettyUtils.sendError(ctx, HttpResponseStatus.CONFLICT, e);
+        } catch (RequestTimeoutException e) {
+            logger.trace("", e);
+            NettyUtils.sendError(ctx, HttpResponseStatus.REQUEST_TIMEOUT, e);
         } catch (MethodNotAllowedException e) {
             logger.trace("", e);
             NettyUtils.sendError(ctx, HttpResponseStatus.METHOD_NOT_ALLOWED, e);

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/RequestTimeoutException.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/RequestTimeoutException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.ml.mms.http;
+
+public class RequestTimeoutException extends RuntimeException {
+
+    static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs an {@code RequestTimeoutException} with the specified detail message.
+     *
+     * @param message The detail message (which is saved for later retrieval by the {@link
+     *     #getMessage()} method)
+     */
+    public RequestTimeoutException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs an {@code RequestTimeoutException} with the specified detail message and cause.
+     *
+     * <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically
+     * incorporated into this exception's detail message.
+     *
+     * @param message The detail message (which is saved for later retrieval by the {@link
+     *     #getMessage()} method)
+     * @param cause The cause (which is saved for later retrieval by the {@link #getCause()}
+     *     method). (A null value is permitted, and indicates that the cause is nonexistent or
+     *     unknown.)
+     */
+    public RequestTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/openapi/OpenApiUtils.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/openapi/OpenApiUtils.java
@@ -388,6 +388,7 @@ public final class OpenApiUtils {
         operation.addResponse(new Response("200", "Model unregistered", status));
         operation.addResponse(new Response("202", "Accepted", status));
         operation.addResponse(new Response("404", "Model not found", error));
+        operation.addResponse(new Response("408", "Request Timeout Error", error));
         operation.addResponse(new Response("500", "Internal Server Error", error));
 
         return operation;

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -65,6 +65,7 @@ public final class ConfigManager {
     private static final String MMS_BLACKLIST_ENV_VARS = "blacklist_env_vars";
     private static final String MMS_DEFAULT_WORKERS_PER_MODEL = "default_workers_per_model";
     private static final String MMS_DEFAULT_RESPONSE_TIMEOUT = "default_response_timeout";
+    private static final String MMS_UNREGISTER_MODEL_TIMEOUT = "unregister_model_timeout";
     private static final String MMS_NUMBER_OF_NETTY_THREADS = "number_of_netty_threads";
     private static final String MMS_NETTY_CLIENT_THREADS = "netty_client_threads";
     private static final String MMS_JOB_QUEUE_SIZE = "job_queue_size";
@@ -523,6 +524,10 @@ public final class ConfigManager {
 
     public int getDefaultResponseTimeout() {
         return Integer.parseInt(prop.getProperty(MMS_DEFAULT_RESPONSE_TIMEOUT, "120"));
+    }
+
+    public int getUnregisterModelTimeout() {
+        return Integer.parseInt(prop.getProperty(MMS_UNREGISTER_MODEL_TIMEOUT, "120"));
     }
 
     private File findMmsHome() {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
@@ -47,6 +47,10 @@ public class WorkerLifeCycle {
         this.model = model;
     }
 
+    public Process getProcess() {
+        return process;
+    }
+
     private String[] getEnvString(String cwd, String modelPath, String handler) {
         ArrayList<String> envList = new ArrayList<>();
         Pattern blackList = configManager.getBlacklistPattern();

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -87,6 +87,10 @@ public class WorkerThread implements Runnable {
         return state;
     }
 
+    public WorkerLifeCycle getLifeCycle() {
+        return lifeCycle;
+    }
+
     public WorkerThread(
             ConfigManager configManager,
             EventLoopGroup backendEventGroup,

--- a/frontend/server/src/test/resources/config.properties
+++ b/frontend/server/src/test/resources/config.properties
@@ -12,6 +12,7 @@ load_models=noop-v0.1,noop-v1.0
 # plugins_path=/tmp/plugins
 async_logging=true
 default_response_timeout=120
+unregister_model_timeout=120
 # number_of_gpu=1
 # cors_allowed_origin
 # cors_allowed_methods

--- a/frontend/server/src/test/resources/config_test_env.properties
+++ b/frontend/server/src/test/resources/config_test_env.properties
@@ -11,6 +11,7 @@ load_models=noop-v0.1,noop-v1.0
 # job_queue_size=100
 async_logging=true
 default_response_timeout=120
+unregister_model_timeout=120
 # number_of_gpu=1
 # cors_allowed_origin
 # cors_allowed_methods

--- a/frontend/server/src/test/resources/management_open_api.json
+++ b/frontend/server/src/test/resources/management_open_api.json
@@ -919,6 +919,35 @@
               }
             }
           },
+          "408": {
+            "description": "Request Timeout Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "type",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "description": "Error code."
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Error type."
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message."
+                    }
+                  }
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal Server Error",
             "content": {

--- a/mms/configs/sagemaker_config.properties
+++ b/mms/configs/sagemaker_config.properties
@@ -3,6 +3,7 @@ model_store=$$SAGEMAKER_MODEL_STORE$$
 inference_address=http://0.0.0.0:$$SAGEMAKER_BIND_TO_PORT$$
 management_address=http://0.0.0.0:$$SAGEMAKER_BIND_TO_PORT$$
 default_response_timeout=$$SAGEMAKER_RESPONSE_TIMEOUT$$
+unregister_model_timeout=$$SAGEMAKER_RESPONSE_TIMEOUT$$
 default_workers_per_model=$$SAGEMAKER_NUM_MODEL_WORKERS$$
 default_service_handler=$$SAGEMAKER_HANDLER$$
 async_logging=true


### PR DESCRIPTION
## Description of changes:
Currently we are sending a response saying that a model has been unregistered and letting the Java's Process library handle actually destroying the resources which means we can have an asynchronous response w/ respect to resource handling. This change ensures we have actually destroyed the resource before sending the response.

## Testing done:

Verified locally w/ log statements (Added log statement to right before the http response is sent back and also after each worker process is actually destroyed, verify that the last thing to happen is the response is sent). Will add a test case if feasible (Java makes it pretty hard to monitor memory usage and our test infrastructure is currently at a client req/resp level).

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
