### PR TITLE
Fix example endpoint code ExecutionParameters.java to work with SageM…

### DIFF
--- a/plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoint/ExecutionParameters.java
+++ b/plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoint/ExecutionParameters.java
@@ -1,9 +1,9 @@
 package software.amazon.ai.mms.plugins.endpoint;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Properties;
 import software.amazon.ai.mms.servingsdk.Context;
 import software.amazon.ai.mms.servingsdk.ModelServerEndpoint;
@@ -12,19 +12,37 @@ import software.amazon.ai.mms.servingsdk.annotations.helpers.EndpointTypes;
 import software.amazon.ai.mms.servingsdk.http.Request;
 import software.amazon.ai.mms.servingsdk.http.Response;
 
+// The modified endpoint source code for the jar used in this container.
+// You can create this endpoint by moving it by cloning the MMS repo:
+// > git clone https://github.com/awslabs/mxnet-model-server.git
+//
+// Copy this file into plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoints/
+// and then from the plugins directory, run:
+//
+// > ./gradlew fJ
+//
+// Modify file in plugins/endpoint/resources/META-INF/services/* to specify this file location
+//
+// Then build the JAR:
+//
+// > ./gradlew build
+//
+// The jar should be available in plugins/endpoints/build/libs as endpoints-1.0.jar
 @Endpoint(
         urlPattern = "execution-parameters",
         endpointType = EndpointTypes.INFERENCE,
         description = "Execution parameters endpoint")
 public class ExecutionParameters extends ModelServerEndpoint {
+
     @Override
     public void doGet(Request req, Response rsp, Context ctx) throws IOException {
         Properties prop = ctx.getConfig();
-        HashMap<String, String> r = new HashMap<>();
-        r.put("MAX_CONCURRENT_TRANSFORMS", prop.getProperty("NUM_WORKERS", "1"));
-        r.put("BATCH_STRATEGY", "SINGLE_RECORD");
-        r.put("MAX_PAYLOAD_IN_MB", prop.getProperty("max_request_size"));
-        r.put("BATCH", "true");
+        // 6 * 1024 * 1024
+        int maxRequestSize = Integer.parseInt(prop.getProperty("max_request_size", "6291456"));
+        SagemakerXgboostResponse r = new SagemakerXgboostResponse();
+        r.setMaxConcurrentTransforms(Integer.parseInt(prop.getProperty("NUM_WORKERS", "1")));
+        r.setBatchStrategy("MULTI_RECORD");
+        r.setMaxPayloadInMB(maxRequestSize / (1024 * 1024));
         rsp.getOutputStream()
                 .write(
                         new GsonBuilder()
@@ -32,5 +50,47 @@ public class ExecutionParameters extends ModelServerEndpoint {
                                 .create()
                                 .toJson(r)
                                 .getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Response for Model server endpoint */
+    public static class SagemakerXgboostResponse {
+        @SerializedName("MaxConcurrentTransforms")
+        private int maxConcurrentTransforms;
+
+        @SerializedName("BatchStrategy")
+        private String batchStrategy;
+
+        @SerializedName("MaxPayloadInMB")
+        private int maxPayloadInMB;
+
+        public SagemakerXgboostResponse() {
+            maxConcurrentTransforms = 4;
+            batchStrategy = "MULTI_RECORD";
+            maxPayloadInMB = 6;
+        }
+
+        public int getMaxConcurrentTransforms() {
+            return maxConcurrentTransforms;
+        }
+
+        public String getBatchStrategy() {
+            return batchStrategy;
+        }
+
+        public int getMaxPayloadInMB() {
+            return maxPayloadInMB;
+        }
+
+        public void setMaxConcurrentTransforms(int newMaxConcurrentTransforms) {
+            maxConcurrentTransforms = newMaxConcurrentTransforms;
+        }
+
+        public void setBatchStrategy(String newBatchStrategy) {
+            batchStrategy = newBatchStrategy;
+        }
+
+        public void setMaxPayloadInMB(int newMaxPayloadInMB) {
+            maxPayloadInMB = newMaxPayloadInMB;
+        }
     }
 }

--- a/plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoint/ExecutionParameters.java
+++ b/plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoint/ExecutionParameters.java
@@ -12,22 +12,6 @@ import software.amazon.ai.mms.servingsdk.annotations.helpers.EndpointTypes;
 import software.amazon.ai.mms.servingsdk.http.Request;
 import software.amazon.ai.mms.servingsdk.http.Response;
 
-// The modified endpoint source code for the jar used in this container.
-// You can create this endpoint by moving it by cloning the MMS repo:
-// > git clone https://github.com/awslabs/mxnet-model-server.git
-//
-// Copy this file into plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoints/
-// and then from the plugins directory, run:
-//
-// > ./gradlew fJ
-//
-// Modify file in plugins/endpoint/resources/META-INF/services/* to specify this file location
-//
-// Then build the JAR:
-//
-// > ./gradlew build
-//
-// The jar should be available in plugins/endpoints/build/libs as endpoints-1.0.jar
 @Endpoint(
         urlPattern = "execution-parameters",
         endpointType = EndpointTypes.INFERENCE,
@@ -39,7 +23,7 @@ public class ExecutionParameters extends ModelServerEndpoint {
         Properties prop = ctx.getConfig();
         // 6 * 1024 * 1024
         int maxRequestSize = Integer.parseInt(prop.getProperty("max_request_size", "6291456"));
-        SagemakerXgboostResponse r = new SagemakerXgboostResponse();
+        ExecutionParametersResponse r = new ExecutionParametersResponse();
         r.setMaxConcurrentTransforms(Integer.parseInt(prop.getProperty("NUM_WORKERS", "1")));
         r.setBatchStrategy("MULTI_RECORD");
         r.setMaxPayloadInMB(maxRequestSize / (1024 * 1024));
@@ -53,7 +37,7 @@ public class ExecutionParameters extends ModelServerEndpoint {
     }
 
     /** Response for Model server endpoint */
-    public static class SagemakerXgboostResponse {
+    public static class ExecutionParametersResponse {
         @SerializedName("MaxConcurrentTransforms")
         private int maxConcurrentTransforms;
 

--- a/plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoint/ExecutionParameters.java
+++ b/plugins/endpoints/src/main/java/software/amazon/ai/mms/plugins/endpoint/ExecutionParameters.java
@@ -47,7 +47,7 @@ public class ExecutionParameters extends ModelServerEndpoint {
         @SerializedName("MaxPayloadInMB")
         private int maxPayloadInMB;
 
-        public SagemakerXgboostResponse() {
+        public ExecutionParametersResponse() {
             maxConcurrentTransforms = 4;
             batchStrategy = "MULTI_RECORD";
             maxPayloadInMB = 6;


### PR DESCRIPTION
…aker batch.

Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:
The endpoint was returning a json of unicode, but MaxConcurrentTransforms and MaxPayloadInMB fields are expected to return int by batch.

## Testing done:
Used endpoint jar in XGBoost: https://github.com/aws/sagemaker-xgboost-container/pull/41

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/mxnet-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
